### PR TITLE
Cumulative bug fixes and improvements (Dec 2018)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ See complete code in [examples/to_rdf.go](examples/to_rdf.go).
 ```go
 proc := ld.NewJsonLdProcessor()
 options := ld.NewJsonLdOptions("")
-options.Format = "application/nquads"
+options.Format = "application/n-quads"
 
 // this JSON-LD document was taken from http://json-ld.org/test-suite/tests/toRdf-0028-in.jsonld
 doc := map[string]interface{}{
@@ -229,7 +229,7 @@ See complete code in [examples/normalize.go](examples/normalize.go).
 ```go
 proc := ld.NewJsonLdProcessor()
 options := ld.NewJsonLdOptions("")
-options.Format = "application/nquads"
+options.Format = "application/n-quads"
 options.Algorithm = "URDNA2015"
 
 doc := map[string]interface{}{

--- a/examples/normalize.go
+++ b/examples/normalize.go
@@ -23,7 +23,7 @@ import (
 func main() {
 	proc := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions("")
-	options.Format = "application/nquads"
+	options.Format = "application/n-quads"
 	options.Algorithm = "URDNA2015"
 
 	doc := map[string]interface{}{

--- a/examples/to_rdf.go
+++ b/examples/to_rdf.go
@@ -25,7 +25,7 @@ import (
 func main() {
 	proc := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions("")
-	options.Format = "application/nquads"
+	options.Format = "application/n-quads"
 
 	// this JSON-LD document was taken from http://json-ld.org/test-suite/tests/toRdf-0028-in.jsonld
 	doc := map[string]interface{}{

--- a/ld/api_normalize.go
+++ b/ld/api_normalize.go
@@ -259,7 +259,7 @@ func (na *NormalisationAlgorithm) Main(dataset *RDFDataset, opts *JsonLdOptions)
 	// 8) Return the normalized dataset.
 	// handle output format
 	if opts.Format != "" {
-		if opts.Format == "application/nquads" {
+		if opts.Format == "application/n-quads" || opts.Format == "application/nquads" {
 			rval := ""
 			for _, n := range normalized {
 				rval += n

--- a/ld/document_loader.go
+++ b/ld/document_loader.go
@@ -83,7 +83,7 @@ func DocumentFromReader(r io.Reader) (interface{}, error) {
 func (dl *DefaultDocumentLoader) LoadDocument(u string) (*RemoteDocument, error) {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
-		return nil, NewJsonLdError(LoadingDocumentFailed, err)
+		return nil, NewJsonLdError(LoadingDocumentFailed, fmt.Sprintf("error parsing URL: %s", u))
 	}
 
 	var documentBody io.Reader
@@ -301,7 +301,7 @@ func (rcdl *RFC7324CachingDocumentLoader) LoadDocument(u string) (*RemoteDocumen
 
 	parsedURL, err := url.Parse(u)
 	if err != nil {
-		return nil, NewJsonLdError(LoadingDocumentFailed, err)
+		return nil, NewJsonLdError(LoadingDocumentFailed, fmt.Sprintf("error parsing URL: %s", u))
 	}
 
 	var documentBody io.Reader

--- a/ld/example_test.go
+++ b/ld/example_test.go
@@ -462,7 +462,7 @@ func ExampleJsonLdProcessor_Frame() {
 func ExampleJsonLdProcessor_ToRDF() {
 	proc := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions("")
-	options.Format = "application/nquads"
+	options.Format = "application/n-quads"
 
 	// this JSON-LD document was taken from http://json-ld.org/test-suite/tests/toRdf-0028-in.jsonld
 	doc := map[string]interface{}{
@@ -555,7 +555,7 @@ func ExampleJsonLdProcessor_FromRDF() {
 func ExampleJsonLdProcessor_Normalize() {
 	proc := ld.NewJsonLdProcessor()
 	options := ld.NewJsonLdOptions("")
-	options.Format = "application/nquads"
+	options.Format = "application/n-quads"
 	options.Algorithm = "URDNA2015"
 
 	doc := map[string]interface{}{

--- a/ld/processor.go
+++ b/ld/processor.go
@@ -359,15 +359,16 @@ func (jldp *JsonLdProcessor) Frame(input interface{}, frame interface{}, opts *J
 }
 
 var rdfSerializers = map[string]RDFSerializer{
-	"application/nquads": &NQuadRDFSerializer{},
-	"text/turtle":        &TurtleRDFSerializer{},
+	"application/n-quads": &NQuadRDFSerializer{},
+	"application/nquads":  &NQuadRDFSerializer{}, // keep this option for backward compatibility
+	"text/turtle":         &TurtleRDFSerializer{},
 }
 
 // FromRDF converts an RDF dataset to JSON-LD.
 //
 // dataset: a serialized string of RDF in a format specified by the format option or an RDF dataset to convert.
 // opts: the options to use:
-//     [format] the format if input is not an array: 'application/nquads' for N-Quads (default).
+//     [format] the format if input is not an array: 'application/n-quads' for N-Quads (default).
 //     [useRdfType] true to use rdf:type, false to use @type (default: false).
 //     [useNativeTypes] true to convert XSD types into native types (boolean, integer, double),
 //     false not to (default: true).
@@ -380,7 +381,7 @@ func (jldp *JsonLdProcessor) FromRDF(dataset interface{}, opts *JsonLdOptions) (
 	// handle non specified serializer case
 	if _, isString := dataset.(string); opts.Format == "" && isString {
 		// attempt to parse the input as nquads
-		opts.Format = "application/nquads"
+		opts.Format = "application/n-quads"
 	}
 
 	serializer, hasSerializer := rdfSerializers[opts.Format]
@@ -423,7 +424,7 @@ func (jldp *JsonLdProcessor) fromRDF(input interface{}, opts *JsonLdOptions, ser
 // input: the JSON-LD input.
 // opts: the options to use:
 //     [base] the base IRI to use.
-//     [format] the format to use to output a string: 'application/nquads' for N-Quads (default).
+//     [format] the format to use to output a string: 'application/n-quads' for N-Quads (default).
 //
 func (jldp *JsonLdProcessor) ToRDF(input interface{}, opts *JsonLdOptions) (interface{}, error) {
 
@@ -485,7 +486,7 @@ func (jldp *JsonLdProcessor) Normalize(input interface{}, opts *JsonLdOptions) (
 
 	var dataset *RDFDataset
 	if opts.InputFormat != "" {
-		if opts.InputFormat != "application/nquads" {
+		if opts.InputFormat != "application/n-quads" && opts.InputFormat != "application/nquads" {
 			return nil, NewJsonLdError(UnknownFormat, "Unknown normalization input format")
 		}
 		serializer, hasSerializer := rdfSerializers[opts.Format]

--- a/ld/processor.go
+++ b/ld/processor.go
@@ -82,7 +82,7 @@ func (jldp *JsonLdProcessor) Compact(input interface{}, context interface{},
 	}
 
 	if compactedMap, isMap := compacted.(map[string]interface{}); len(compactedMap) > 0 && isMap {
-		if contextList, isList := context.([]interface{}); isList && len(contextList) == 1 {
+		if contextList, isList := context.([]interface{}); isList && len(contextList) == 1 && opts.CompactArrays {
 			// if the context is an array with 1 element, compact the array
 			compactedMap["@context"] = contextList[0]
 		} else if contextMap, isMap := context.(map[string]interface{}); len(contextMap) > 0 || !isMap {

--- a/ld/processor.go
+++ b/ld/processor.go
@@ -347,7 +347,7 @@ func (jldp *JsonLdProcessor) Frame(input interface{}, frame interface{}, opts *J
 		return nil, err
 	}
 
-	compacted, _ := api.Compact(activeCtx, "", framed, true)
+	compacted, _ := api.Compact(activeCtx, "", framed, opts.CompactArrays)
 	if _, isList := compacted.([]interface{}); !isList {
 		compacted = []interface{}{compacted}
 	}

--- a/ld/processor.go
+++ b/ld/processor.go
@@ -81,12 +81,16 @@ func (jldp *JsonLdProcessor) Compact(input interface{}, context interface{},
 		}
 	}
 
-	contextMap, _ = context.(map[string]interface{})
-	contextList, _ := context.([]interface{})
-	contextIsNotEmpty := len(contextMap) > 0 || len(contextList) > 0
-	if compactedMap, isMap := compacted.(map[string]interface{}); contextIsNotEmpty && isMap {
-		// TODO: figure out if we can make "@context" appear at the start of the keySet
-		compactedMap["@context"] = context
+	if compactedMap, isMap := compacted.(map[string]interface{}); len(compactedMap) > 0 && isMap {
+		if contextList, isList := context.([]interface{}); isList && len(contextList) == 1 {
+			// if the context is an array with 1 element, compact the array
+			compactedMap["@context"] = contextList[0]
+		} else if contextMap, isMap := context.(map[string]interface{}); len(contextMap) > 0 || !isMap {
+			// otherwise keep the context as is
+			compactedMap["@context"] = context
+		} else {
+			// unless it's empty, then omit the context altogether
+		}
 	}
 
 	// 9)

--- a/ld/processor.go
+++ b/ld/processor.go
@@ -412,7 +412,7 @@ func (jldp *JsonLdProcessor) fromRDF(input interface{}, opts *JsonLdOptions, ser
 		} else if opts.OutputForm == "flattened" {
 			return jldp.Flatten(rval, dataset.context, opts)
 		} else {
-			return nil, NewJsonLdError(UnknownError, "")
+			return nil, NewJsonLdError(UnknownError, fmt.Sprintf("Output form was unknown: %s", opts.OutputForm))
 		}
 	}
 	return rval, nil

--- a/ld/processor_test.go
+++ b/ld/processor_test.go
@@ -394,7 +394,7 @@ func TestSuite(t *testing.T) {
 			case "jld:ToRDFTest":
 				log.Println("Running ToRDF test", td.Id, ":", td.Name)
 
-				options.Format = "application/nquads"
+				options.Format = "application/n-quads"
 				result, opError = proc.ToRDF(td.InputURL, options)
 			case "rdfn:Urgna2012EvalTest":
 				log.Println("Running URGNA2012 test", td.Id, ":", td.Name)
@@ -402,8 +402,8 @@ func TestSuite(t *testing.T) {
 				inputBytes, err := ioutil.ReadFile(td.InputFileName)
 				assert.NoError(t, err)
 				input := string(inputBytes)
-				options.InputFormat = "application/nquads"
-				options.Format = "application/nquads"
+				options.InputFormat = "application/n-quads"
+				options.Format = "application/n-quads"
 				options.Algorithm = "URGNA2012"
 				result, opError = proc.Normalize(input, options)
 			case "rdfn:Urdna2015EvalTest":
@@ -412,8 +412,8 @@ func TestSuite(t *testing.T) {
 				inputBytes, err := ioutil.ReadFile(td.InputFileName)
 				assert.NoError(t, err)
 				input := string(inputBytes)
-				options.InputFormat = "application/nquads"
-				options.Format = "application/nquads"
+				options.InputFormat = "application/n-quads"
+				options.Format = "application/n-quads"
 				options.Algorithm = "URDNA2015"
 				result, opError = proc.Normalize(input, options)
 			default:


### PR DESCRIPTION
These fixes were ported from https://github.com/jsonld-java/jsonld-java (various commits from 2015-2017). Most of them are related to edge cases. One notable exception is the way the compaction algorithm handles single remote contexts: they were omitted from the output before this fix.