### PR TITLE
Fix #27: recursive context inclusion error

### DIFF
--- a/ld/context.go
+++ b/ld/context.go
@@ -199,7 +199,9 @@ func (c *Context) parse(localContext interface{}, remoteContexts []string, parsi
 			}
 
 			// 3.2.4
-			resultRef, err := result.parse(context, remoteContexts, true, true, false, overrideProtected)
+			remoteContextsCpy := make([]string, 0, len(remoteContexts))
+			copy(remoteContextsCpy, remoteContexts)
+			resultRef, err := result.parse(context, remoteContextsCpy, true, true, false, overrideProtected)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
The code wasn't making a copy of the list of remote contexts it already processed. As a result, if the same context was included twice, it was breaking with _recursive context inclusion_ error.