### PR TITLE
Add support for rel=alternate for non-JSON-LD docs

### DIFF
--- a/conformance_report.jsonld
+++ b/conformance_report.jsonld
@@ -45,7 +45,7 @@
   "dc:creator": "https://github.com/kazarena",
   "dc:date": {
     "@type": "xsd:date",
-    "@value": "2020-04-06"
+    "@value": "2020-08-17"
   },
   "dc:title": "JSON-goLD",
   "doap:description": "A JSON-LD processor for Go",
@@ -67,7 +67,7 @@
     "@type": "doap:Version",
     "doap:created": {
       "@type": "xsd:date",
-      "@value": "2020-04-06"
+      "@value": "2020-08-17"
     },
     "doap:name": "json-gold-v0.3.0",
     "doap:revision": "v0.3.0"
@@ -79,7 +79,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.676634",
+        "dc:date": "2020-08-17T22:41:49.874612",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0001"
@@ -90,7 +90,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.677862",
+        "dc:date": "2020-08-17T22:41:49.875694",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0002"
@@ -101,7 +101,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.678636",
+        "dc:date": "2020-08-17T22:41:49.876371",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0003"
@@ -112,7 +112,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.679478",
+        "dc:date": "2020-08-17T22:41:49.877356",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0004"
@@ -123,7 +123,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.680162",
+        "dc:date": "2020-08-17T22:41:49.87825",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0005"
@@ -134,7 +134,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.680952",
+        "dc:date": "2020-08-17T22:41:49.879054",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0006"
@@ -145,7 +145,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.681866",
+        "dc:date": "2020-08-17T22:41:49.880105",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0007"
@@ -156,7 +156,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.682604",
+        "dc:date": "2020-08-17T22:41:49.880948",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0008"
@@ -167,7 +167,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.683302",
+        "dc:date": "2020-08-17T22:41:49.881697",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0009"
@@ -178,7 +178,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.683985",
+        "dc:date": "2020-08-17T22:41:49.882431",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0010"
@@ -189,7 +189,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.684725",
+        "dc:date": "2020-08-17T22:41:49.883234",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0011"
@@ -200,7 +200,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.685348",
+        "dc:date": "2020-08-17T22:41:49.883861",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0012"
@@ -211,7 +211,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.685985",
+        "dc:date": "2020-08-17T22:41:49.884502",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0013"
@@ -222,7 +222,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.686757",
+        "dc:date": "2020-08-17T22:41:49.88521",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0014"
@@ -233,7 +233,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.687635",
+        "dc:date": "2020-08-17T22:41:49.886027",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0015"
@@ -244,7 +244,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.688333",
+        "dc:date": "2020-08-17T22:41:49.886776",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0016"
@@ -255,7 +255,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.689026",
+        "dc:date": "2020-08-17T22:41:49.887451",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0017"
@@ -266,7 +266,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.690144",
+        "dc:date": "2020-08-17T22:41:49.888587",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0018"
@@ -277,7 +277,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.690861",
+        "dc:date": "2020-08-17T22:41:49.889309",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0019"
@@ -288,7 +288,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.691646",
+        "dc:date": "2020-08-17T22:41:49.8899",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0020"
@@ -299,7 +299,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.693387",
+        "dc:date": "2020-08-17T22:41:49.890585",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0021"
@@ -310,7 +310,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.694153",
+        "dc:date": "2020-08-17T22:41:49.891365",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0022"
@@ -321,7 +321,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.694876",
+        "dc:date": "2020-08-17T22:41:49.892031",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0023"
@@ -332,7 +332,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.695922",
+        "dc:date": "2020-08-17T22:41:49.893041",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0024"
@@ -343,7 +343,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.696625",
+        "dc:date": "2020-08-17T22:41:49.894198",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0025"
@@ -354,7 +354,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.697801",
+        "dc:date": "2020-08-17T22:41:49.895097",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0026"
@@ -365,7 +365,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.698589",
+        "dc:date": "2020-08-17T22:41:49.895814",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0027"
@@ -376,7 +376,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.699301",
+        "dc:date": "2020-08-17T22:41:49.896561",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0028"
@@ -387,7 +387,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.700061",
+        "dc:date": "2020-08-17T22:41:49.897283",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0029"
@@ -398,7 +398,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.701708",
+        "dc:date": "2020-08-17T22:41:49.898357",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0030"
@@ -409,7 +409,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.702467",
+        "dc:date": "2020-08-17T22:41:49.899042",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0031"
@@ -420,7 +420,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.703153",
+        "dc:date": "2020-08-17T22:41:49.899756",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0032"
@@ -431,7 +431,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.70386",
+        "dc:date": "2020-08-17T22:41:49.900435",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0033"
@@ -442,7 +442,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.704706",
+        "dc:date": "2020-08-17T22:41:49.90114",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0034"
@@ -453,7 +453,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.705439",
+        "dc:date": "2020-08-17T22:41:49.901856",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0035"
@@ -464,7 +464,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.706137",
+        "dc:date": "2020-08-17T22:41:49.902639",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0036"
@@ -475,7 +475,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.706944",
+        "dc:date": "2020-08-17T22:41:49.903388",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0037"
@@ -486,7 +486,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.708285",
+        "dc:date": "2020-08-17T22:41:49.904687",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ta038"
@@ -497,7 +497,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.708936",
+        "dc:date": "2020-08-17T22:41:49.905313",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0039"
@@ -508,7 +508,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.709459",
+        "dc:date": "2020-08-17T22:41:49.905938",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0040"
@@ -519,7 +519,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.710081",
+        "dc:date": "2020-08-17T22:41:49.906582",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0041"
@@ -530,7 +530,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.710717",
+        "dc:date": "2020-08-17T22:41:49.907231",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0042"
@@ -541,7 +541,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.711302",
+        "dc:date": "2020-08-17T22:41:49.907856",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0043"
@@ -552,7 +552,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.712107",
+        "dc:date": "2020-08-17T22:41:49.908645",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0044"
@@ -563,7 +563,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.712867",
+        "dc:date": "2020-08-17T22:41:49.909602",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0045"
@@ -574,7 +574,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.713453",
+        "dc:date": "2020-08-17T22:41:49.910258",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0046"
@@ -585,7 +585,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.714136",
+        "dc:date": "2020-08-17T22:41:49.910941",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0047"
@@ -596,7 +596,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.714819",
+        "dc:date": "2020-08-17T22:41:49.911685",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0048"
@@ -607,7 +607,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.71551",
+        "dc:date": "2020-08-17T22:41:49.912429",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0049"
@@ -618,7 +618,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.71623",
+        "dc:date": "2020-08-17T22:41:49.913218",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0050"
@@ -629,7 +629,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.71681",
+        "dc:date": "2020-08-17T22:41:49.913851",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0051"
@@ -640,7 +640,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.717474",
+        "dc:date": "2020-08-17T22:41:49.914625",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0052"
@@ -651,7 +651,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.718062",
+        "dc:date": "2020-08-17T22:41:49.91526",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0053"
@@ -662,7 +662,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.718694",
+        "dc:date": "2020-08-17T22:41:49.915922",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0054"
@@ -673,7 +673,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.719349",
+        "dc:date": "2020-08-17T22:41:49.916597",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0055"
@@ -684,7 +684,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.720013",
+        "dc:date": "2020-08-17T22:41:49.917276",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0056"
@@ -695,7 +695,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.721023",
+        "dc:date": "2020-08-17T22:41:49.918257",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0057"
@@ -706,7 +706,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.721662",
+        "dc:date": "2020-08-17T22:41:49.918928",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0058"
@@ -717,7 +717,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.722358",
+        "dc:date": "2020-08-17T22:41:49.919561",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0059"
@@ -728,7 +728,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.723074",
+        "dc:date": "2020-08-17T22:41:49.920291",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0060"
@@ -739,7 +739,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.723857",
+        "dc:date": "2020-08-17T22:41:49.92113",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0061"
@@ -750,7 +750,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.724857",
+        "dc:date": "2020-08-17T22:41:49.921899",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0062"
@@ -761,7 +761,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.725704",
+        "dc:date": "2020-08-17T22:41:49.922572",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0063"
@@ -772,7 +772,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.726442",
+        "dc:date": "2020-08-17T22:41:49.923338",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0064"
@@ -783,7 +783,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.727234",
+        "dc:date": "2020-08-17T22:41:49.924016",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0065"
@@ -794,7 +794,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.728433",
+        "dc:date": "2020-08-17T22:41:49.925388",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0066"
@@ -805,7 +805,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.729132",
+        "dc:date": "2020-08-17T22:41:49.926137",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0067"
@@ -816,7 +816,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.729877",
+        "dc:date": "2020-08-17T22:41:49.926919",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0068"
@@ -827,7 +827,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.730602",
+        "dc:date": "2020-08-17T22:41:49.927706",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0069"
@@ -838,7 +838,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.731261",
+        "dc:date": "2020-08-17T22:41:49.928429",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0070"
@@ -849,7 +849,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.732003",
+        "dc:date": "2020-08-17T22:41:49.929235",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0071"
@@ -860,7 +860,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.732581",
+        "dc:date": "2020-08-17T22:41:49.929873",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0072"
@@ -871,7 +871,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.733221",
+        "dc:date": "2020-08-17T22:41:49.930653",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0073"
@@ -882,7 +882,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.733873",
+        "dc:date": "2020-08-17T22:41:49.931314",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0074"
@@ -893,7 +893,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.734545",
+        "dc:date": "2020-08-17T22:41:49.931971",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0075"
@@ -904,7 +904,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.735075",
+        "dc:date": "2020-08-17T22:41:49.932628",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0076"
@@ -915,7 +915,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.735805",
+        "dc:date": "2020-08-17T22:41:49.933348",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0077"
@@ -926,7 +926,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.736474",
+        "dc:date": "2020-08-17T22:41:49.934066",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0078"
@@ -937,7 +937,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.737121",
+        "dc:date": "2020-08-17T22:41:49.934714",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0079"
@@ -948,7 +948,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.738089",
+        "dc:date": "2020-08-17T22:41:49.935373",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0080"
@@ -959,7 +959,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.739343",
+        "dc:date": "2020-08-17T22:41:49.936002",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0081"
@@ -970,7 +970,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.740066",
+        "dc:date": "2020-08-17T22:41:49.936687",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0082"
@@ -981,7 +981,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.740738",
+        "dc:date": "2020-08-17T22:41:49.937281",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0083"
@@ -992,7 +992,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.741392",
+        "dc:date": "2020-08-17T22:41:49.937946",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0084"
@@ -1003,7 +1003,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.742025",
+        "dc:date": "2020-08-17T22:41:49.938571",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0085"
@@ -1014,7 +1014,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.742692",
+        "dc:date": "2020-08-17T22:41:49.939171",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0086"
@@ -1025,7 +1025,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.743326",
+        "dc:date": "2020-08-17T22:41:49.93986",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0087"
@@ -1036,7 +1036,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.743945",
+        "dc:date": "2020-08-17T22:41:49.940497",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0088"
@@ -1047,7 +1047,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.744618",
+        "dc:date": "2020-08-17T22:41:49.941195",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0089"
@@ -1058,7 +1058,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.745294",
+        "dc:date": "2020-08-17T22:41:49.941879",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0090"
@@ -1069,7 +1069,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.745925",
+        "dc:date": "2020-08-17T22:41:49.942535",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0091"
@@ -1080,7 +1080,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.746666",
+        "dc:date": "2020-08-17T22:41:49.943226",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0092"
@@ -1091,7 +1091,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.747381",
+        "dc:date": "2020-08-17T22:41:49.943938",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0093"
@@ -1102,7 +1102,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.748069",
+        "dc:date": "2020-08-17T22:41:49.944708",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0094"
@@ -1113,7 +1113,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.74876",
+        "dc:date": "2020-08-17T22:41:49.945439",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0095"
@@ -1124,7 +1124,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.749376",
+        "dc:date": "2020-08-17T22:41:49.946197",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0096"
@@ -1135,7 +1135,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.750078",
+        "dc:date": "2020-08-17T22:41:49.946889",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0097"
@@ -1146,7 +1146,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.750758",
+        "dc:date": "2020-08-17T22:41:49.947527",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0098"
@@ -1157,7 +1157,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.751353",
+        "dc:date": "2020-08-17T22:41:49.948114",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0099"
@@ -1168,7 +1168,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.751974",
+        "dc:date": "2020-08-17T22:41:49.948731",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0100"
@@ -1179,7 +1179,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.752658",
+        "dc:date": "2020-08-17T22:41:49.949281",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0101"
@@ -1190,7 +1190,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.753355",
+        "dc:date": "2020-08-17T22:41:49.949963",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0102"
@@ -1201,7 +1201,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.753999",
+        "dc:date": "2020-08-17T22:41:49.950611",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0103"
@@ -1212,7 +1212,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.754798",
+        "dc:date": "2020-08-17T22:41:49.951207",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0104"
@@ -1223,7 +1223,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.755939",
+        "dc:date": "2020-08-17T22:41:49.951806",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0105"
@@ -1234,7 +1234,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.757433",
+        "dc:date": "2020-08-17T22:41:49.952382",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0106"
@@ -1245,7 +1245,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.758097",
+        "dc:date": "2020-08-17T22:41:49.953042",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0107"
@@ -1256,7 +1256,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.758772",
+        "dc:date": "2020-08-17T22:41:49.953751",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0108"
@@ -1267,7 +1267,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.759468",
+        "dc:date": "2020-08-17T22:41:49.9544",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0109"
@@ -1278,7 +1278,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.75995",
+        "dc:date": "2020-08-17T22:41:49.954823",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#t0110"
@@ -1289,7 +1289,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.76058",
+        "dc:date": "2020-08-17T22:41:49.955431",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc001"
@@ -1300,7 +1300,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.76124",
+        "dc:date": "2020-08-17T22:41:49.956098",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc002"
@@ -1311,7 +1311,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.761856",
+        "dc:date": "2020-08-17T22:41:49.956723",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc003"
@@ -1322,7 +1322,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.762508",
+        "dc:date": "2020-08-17T22:41:49.957373",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc004"
@@ -1333,7 +1333,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.763222",
+        "dc:date": "2020-08-17T22:41:49.958036",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc005"
@@ -1344,7 +1344,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.763852",
+        "dc:date": "2020-08-17T22:41:49.95904",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc006"
@@ -1355,7 +1355,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.764532",
+        "dc:date": "2020-08-17T22:41:49.959702",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc007"
@@ -1366,7 +1366,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.765218",
+        "dc:date": "2020-08-17T22:41:49.960336",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc008"
@@ -1377,7 +1377,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.766317",
+        "dc:date": "2020-08-17T22:41:49.960951",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc009"
@@ -1388,7 +1388,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.767004",
+        "dc:date": "2020-08-17T22:41:49.961582",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc010"
@@ -1399,7 +1399,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.767748",
+        "dc:date": "2020-08-17T22:41:49.962295",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc011"
@@ -1410,7 +1410,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.7685",
+        "dc:date": "2020-08-17T22:41:49.96298",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc012"
@@ -1421,7 +1421,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.769152",
+        "dc:date": "2020-08-17T22:41:49.963578",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc013"
@@ -1432,7 +1432,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.769852",
+        "dc:date": "2020-08-17T22:41:49.964192",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc014"
@@ -1443,7 +1443,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.770498",
+        "dc:date": "2020-08-17T22:41:49.964742",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc015"
@@ -1454,7 +1454,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.771012",
+        "dc:date": "2020-08-17T22:41:49.965162",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc016"
@@ -1465,7 +1465,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.771554",
+        "dc:date": "2020-08-17T22:41:49.965662",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc017"
@@ -1476,7 +1476,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.771983",
+        "dc:date": "2020-08-17T22:41:49.966143",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc018"
@@ -1487,7 +1487,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.772591",
+        "dc:date": "2020-08-17T22:41:49.966759",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc019"
@@ -1498,7 +1498,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.773104",
+        "dc:date": "2020-08-17T22:41:49.9673",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc020"
@@ -1509,7 +1509,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.773687",
+        "dc:date": "2020-08-17T22:41:49.967895",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc021"
@@ -1520,7 +1520,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.774161",
+        "dc:date": "2020-08-17T22:41:49.968427",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc022"
@@ -1531,7 +1531,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.774798",
+        "dc:date": "2020-08-17T22:41:49.969021",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc023"
@@ -1542,7 +1542,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.77546",
+        "dc:date": "2020-08-17T22:41:49.969696",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc024"
@@ -1553,7 +1553,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.776038",
+        "dc:date": "2020-08-17T22:41:49.970235",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc025"
@@ -1564,7 +1564,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.776522",
+        "dc:date": "2020-08-17T22:41:49.970657",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc026"
@@ -1575,7 +1575,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.776956",
+        "dc:date": "2020-08-17T22:41:49.971023",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tc027"
@@ -1586,7 +1586,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.777337",
+        "dc:date": "2020-08-17T22:41:49.971428",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi01"
@@ -1597,7 +1597,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.777734",
+        "dc:date": "2020-08-17T22:41:49.971845",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi02"
@@ -1608,7 +1608,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.778239",
+        "dc:date": "2020-08-17T22:41:49.972283",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi03"
@@ -1619,7 +1619,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.778793",
+        "dc:date": "2020-08-17T22:41:49.972742",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi04"
@@ -1630,7 +1630,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.779261",
+        "dc:date": "2020-08-17T22:41:49.973237",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi05"
@@ -1641,7 +1641,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.779917",
+        "dc:date": "2020-08-17T22:41:49.973893",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi06"
@@ -1652,7 +1652,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.780661",
+        "dc:date": "2020-08-17T22:41:49.974571",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tdi07"
@@ -1663,7 +1663,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.781177",
+        "dc:date": "2020-08-17T22:41:49.975043",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#te002"
@@ -1674,7 +1674,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.781669",
+        "dc:date": "2020-08-17T22:41:49.975452",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ten01"
@@ -1685,7 +1685,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.782023",
+        "dc:date": "2020-08-17T22:41:49.97588",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep05"
@@ -1696,7 +1696,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.782426",
+        "dc:date": "2020-08-17T22:41:49.976295",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep06"
@@ -1707,7 +1707,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.782784",
+        "dc:date": "2020-08-17T22:41:49.976704",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep07"
@@ -1718,7 +1718,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.7832",
+        "dc:date": "2020-08-17T22:41:49.977156",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep08"
@@ -1729,7 +1729,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.783642",
+        "dc:date": "2020-08-17T22:41:49.977727",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep09"
@@ -1740,7 +1740,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.784002",
+        "dc:date": "2020-08-17T22:41:49.978184",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep10"
@@ -1751,7 +1751,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.784454",
+        "dc:date": "2020-08-17T22:41:49.978626",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep11"
@@ -1762,7 +1762,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.784843",
+        "dc:date": "2020-08-17T22:41:49.979112",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep12"
@@ -1773,7 +1773,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.785298",
+        "dc:date": "2020-08-17T22:41:49.979551",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep13"
@@ -1784,7 +1784,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.785884",
+        "dc:date": "2020-08-17T22:41:49.980036",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep14"
@@ -1795,7 +1795,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.787182",
+        "dc:date": "2020-08-17T22:41:49.98048",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tep15"
@@ -1806,7 +1806,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.787189",
+        "dc:date": "2020-08-17T22:41:49.980487",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tin01"
@@ -1817,7 +1817,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.787192",
+        "dc:date": "2020-08-17T22:41:49.980491",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tin02"
@@ -1828,7 +1828,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.787195",
+        "dc:date": "2020-08-17T22:41:49.980494",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tin03"
@@ -1839,7 +1839,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.787199",
+        "dc:date": "2020-08-17T22:41:49.980496",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tin04"
@@ -1850,7 +1850,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.787207",
+        "dc:date": "2020-08-17T22:41:49.9805",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tin05"
@@ -1861,7 +1861,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.78804",
+        "dc:date": "2020-08-17T22:41:49.981208",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs01"
@@ -1872,7 +1872,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.788681",
+        "dc:date": "2020-08-17T22:41:49.981909",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs02"
@@ -1883,7 +1883,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.789301",
+        "dc:date": "2020-08-17T22:41:49.98266",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs03"
@@ -1894,7 +1894,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.789922",
+        "dc:date": "2020-08-17T22:41:49.983396",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs04"
@@ -1905,7 +1905,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.790565",
+        "dc:date": "2020-08-17T22:41:49.984085",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs05"
@@ -1916,7 +1916,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.791234",
+        "dc:date": "2020-08-17T22:41:49.984716",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs06"
@@ -1927,7 +1927,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.791632",
+        "dc:date": "2020-08-17T22:41:49.985156",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs07"
@@ -1938,7 +1938,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.792014",
+        "dc:date": "2020-08-17T22:41:49.985556",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs08"
@@ -1949,7 +1949,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.792435",
+        "dc:date": "2020-08-17T22:41:49.986463",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs09"
@@ -1960,7 +1960,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.79281",
+        "dc:date": "2020-08-17T22:41:49.987032",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs10"
@@ -1971,7 +1971,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.793227",
+        "dc:date": "2020-08-17T22:41:49.987435",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tjs11"
@@ -1982,7 +1982,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.794526",
+        "dc:date": "2020-08-17T22:41:49.988309",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tla01"
@@ -1993,7 +1993,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.795232",
+        "dc:date": "2020-08-17T22:41:49.988914",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tli01"
@@ -2004,7 +2004,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.795899",
+        "dc:date": "2020-08-17T22:41:49.989597",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tli02"
@@ -2015,7 +2015,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.796551",
+        "dc:date": "2020-08-17T22:41:49.990215",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tli03"
@@ -2026,7 +2026,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.797181",
+        "dc:date": "2020-08-17T22:41:49.990861",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tli04"
@@ -2037,7 +2037,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.797807",
+        "dc:date": "2020-08-17T22:41:49.991522",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tli05"
@@ -2048,7 +2048,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.798471",
+        "dc:date": "2020-08-17T22:41:49.992215",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm001"
@@ -2059,7 +2059,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.799185",
+        "dc:date": "2020-08-17T22:41:49.992882",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm002"
@@ -2070,7 +2070,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.799882",
+        "dc:date": "2020-08-17T22:41:49.993578",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm003"
@@ -2081,7 +2081,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.800539",
+        "dc:date": "2020-08-17T22:41:49.994232",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm004"
@@ -2092,7 +2092,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.801428",
+        "dc:date": "2020-08-17T22:41:49.994913",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm005"
@@ -2103,7 +2103,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.802072",
+        "dc:date": "2020-08-17T22:41:49.995491",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm006"
@@ -2114,7 +2114,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.802707",
+        "dc:date": "2020-08-17T22:41:49.99612",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm007"
@@ -2125,7 +2125,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.803462",
+        "dc:date": "2020-08-17T22:41:49.996775",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm008"
@@ -2136,7 +2136,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.804083",
+        "dc:date": "2020-08-17T22:41:49.997427",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm009"
@@ -2147,7 +2147,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.804733",
+        "dc:date": "2020-08-17T22:41:49.998113",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm010"
@@ -2158,7 +2158,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.805366",
+        "dc:date": "2020-08-17T22:41:49.998812",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm011"
@@ -2169,7 +2169,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.806051",
+        "dc:date": "2020-08-17T22:41:49.999544",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm012"
@@ -2180,7 +2180,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.806685",
+        "dc:date": "2020-08-17T22:41:50.000224",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm013"
@@ -2191,7 +2191,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.807301",
+        "dc:date": "2020-08-17T22:41:50.000913",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm014"
@@ -2202,7 +2202,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.807963",
+        "dc:date": "2020-08-17T22:41:50.001586",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm015"
@@ -2213,7 +2213,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.808651",
+        "dc:date": "2020-08-17T22:41:50.002291",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm016"
@@ -2224,7 +2224,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.809307",
+        "dc:date": "2020-08-17T22:41:50.002915",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm017"
@@ -2235,7 +2235,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.810009",
+        "dc:date": "2020-08-17T22:41:50.003512",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm018"
@@ -2246,7 +2246,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.810613",
+        "dc:date": "2020-08-17T22:41:50.004147",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm019"
@@ -2257,7 +2257,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.811199",
+        "dc:date": "2020-08-17T22:41:50.004831",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm020"
@@ -2268,7 +2268,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.811803",
+        "dc:date": "2020-08-17T22:41:50.005527",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm021"
@@ -2279,7 +2279,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.812462",
+        "dc:date": "2020-08-17T22:41:50.006163",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tm022"
@@ -2290,7 +2290,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.813039",
+        "dc:date": "2020-08-17T22:41:50.006775",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn001"
@@ -2301,7 +2301,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.813567",
+        "dc:date": "2020-08-17T22:41:50.007394",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn002"
@@ -2312,7 +2312,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.81419",
+        "dc:date": "2020-08-17T22:41:50.007967",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn003"
@@ -2323,7 +2323,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.814733",
+        "dc:date": "2020-08-17T22:41:50.008564",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn004"
@@ -2334,7 +2334,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.815286",
+        "dc:date": "2020-08-17T22:41:50.009185",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn005"
@@ -2345,7 +2345,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.815905",
+        "dc:date": "2020-08-17T22:41:50.009821",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn006"
@@ -2356,7 +2356,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.817703",
+        "dc:date": "2020-08-17T22:41:50.010473",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn007"
@@ -2367,7 +2367,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.818484",
+        "dc:date": "2020-08-17T22:41:50.011245",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn008"
@@ -2378,7 +2378,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.819273",
+        "dc:date": "2020-08-17T22:41:50.011984",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn009"
@@ -2389,7 +2389,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.820027",
+        "dc:date": "2020-08-17T22:41:50.012635",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn010"
@@ -2400,7 +2400,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.820681",
+        "dc:date": "2020-08-17T22:41:50.013295",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tn011"
@@ -2411,7 +2411,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.820689",
+        "dc:date": "2020-08-17T22:41:50.013303",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp001"
@@ -2422,7 +2422,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.821377",
+        "dc:date": "2020-08-17T22:41:50.013989",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp002"
@@ -2433,7 +2433,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.821951",
+        "dc:date": "2020-08-17T22:41:50.014642",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp003"
@@ -2444,7 +2444,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.822634",
+        "dc:date": "2020-08-17T22:41:50.015447",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp004"
@@ -2455,7 +2455,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.823293",
+        "dc:date": "2020-08-17T22:41:50.016139",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp005"
@@ -2466,7 +2466,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.823981",
+        "dc:date": "2020-08-17T22:41:50.016777",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp006"
@@ -2477,7 +2477,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.824587",
+        "dc:date": "2020-08-17T22:41:50.017421",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp007"
@@ -2488,7 +2488,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.8253",
+        "dc:date": "2020-08-17T22:41:50.018047",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tp008"
@@ -2499,7 +2499,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.825833",
+        "dc:date": "2020-08-17T22:41:50.018549",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi01"
@@ -2510,7 +2510,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.826389",
+        "dc:date": "2020-08-17T22:41:50.019385",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi02"
@@ -2521,7 +2521,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.826979",
+        "dc:date": "2020-08-17T22:41:50.020064",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi03"
@@ -2532,7 +2532,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.827575",
+        "dc:date": "2020-08-17T22:41:50.020655",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi04"
@@ -2543,7 +2543,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.828032",
+        "dc:date": "2020-08-17T22:41:50.021178",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi05"
@@ -2554,7 +2554,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.828978",
+        "dc:date": "2020-08-17T22:41:50.021725",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpi06"
@@ -2565,7 +2565,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.829288",
+        "dc:date": "2020-08-17T22:41:50.022034",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr01"
@@ -2576,7 +2576,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.82971",
+        "dc:date": "2020-08-17T22:41:50.022484",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr02"
@@ -2587,7 +2587,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.830187",
+        "dc:date": "2020-08-17T22:41:50.023005",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr03"
@@ -2598,7 +2598,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.830929",
+        "dc:date": "2020-08-17T22:41:50.023682",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr04"
@@ -2609,7 +2609,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.831622",
+        "dc:date": "2020-08-17T22:41:50.024402",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tpr05"
@@ -2620,7 +2620,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.832529",
+        "dc:date": "2020-08-17T22:41:50.025023",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tr001"
@@ -2631,7 +2631,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.833235",
+        "dc:date": "2020-08-17T22:41:50.025677",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#tr002"
@@ -2642,7 +2642,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.834195",
+        "dc:date": "2020-08-17T22:41:50.026559",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ts001"
@@ -2653,7 +2653,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.835015",
+        "dc:date": "2020-08-17T22:41:50.027446",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ts002"
@@ -2664,7 +2664,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.835856",
+        "dc:date": "2020-08-17T22:41:50.028246",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn01"
@@ -2675,7 +2675,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.836575",
+        "dc:date": "2020-08-17T22:41:50.028938",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn02"
@@ -2686,7 +2686,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.837227",
+        "dc:date": "2020-08-17T22:41:50.029649",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/compact-manifest#ttn03"
@@ -2697,7 +2697,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.840978",
+        "dc:date": "2020-08-17T22:41:50.033212",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0001"
@@ -2708,7 +2708,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.841538",
+        "dc:date": "2020-08-17T22:41:50.033744",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0002"
@@ -2719,7 +2719,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.842004",
+        "dc:date": "2020-08-17T22:41:50.03416",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0003"
@@ -2730,7 +2730,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.842599",
+        "dc:date": "2020-08-17T22:41:50.034784",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0004"
@@ -2741,7 +2741,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.8432",
+        "dc:date": "2020-08-17T22:41:50.035383",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0005"
@@ -2752,7 +2752,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.843684",
+        "dc:date": "2020-08-17T22:41:50.035909",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0006"
@@ -2763,7 +2763,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.84423",
+        "dc:date": "2020-08-17T22:41:50.036419",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0007"
@@ -2774,7 +2774,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.844713",
+        "dc:date": "2020-08-17T22:41:50.036864",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0008"
@@ -2785,7 +2785,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.845397",
+        "dc:date": "2020-08-17T22:41:50.038049",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0009"
@@ -2796,7 +2796,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.845839",
+        "dc:date": "2020-08-17T22:41:50.038636",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0010"
@@ -2807,7 +2807,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.846384",
+        "dc:date": "2020-08-17T22:41:50.039185",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0011"
@@ -2818,7 +2818,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.846925",
+        "dc:date": "2020-08-17T22:41:50.039839",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0012"
@@ -2829,7 +2829,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.847476",
+        "dc:date": "2020-08-17T22:41:50.040306",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0013"
@@ -2840,7 +2840,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.850121",
+        "dc:date": "2020-08-17T22:41:50.040942",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0014"
@@ -2851,7 +2851,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.850725",
+        "dc:date": "2020-08-17T22:41:50.041502",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0015"
@@ -2862,7 +2862,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.851452",
+        "dc:date": "2020-08-17T22:41:50.04208",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0016"
@@ -2873,7 +2873,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.852185",
+        "dc:date": "2020-08-17T22:41:50.04287",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0017"
@@ -2884,7 +2884,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.852769",
+        "dc:date": "2020-08-17T22:41:50.045098",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0018"
@@ -2895,7 +2895,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.853172",
+        "dc:date": "2020-08-17T22:41:50.045661",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0019"
@@ -2906,7 +2906,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.853838",
+        "dc:date": "2020-08-17T22:41:50.04654",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0020"
@@ -2917,7 +2917,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.854605",
+        "dc:date": "2020-08-17T22:41:50.047387",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0021"
@@ -2928,7 +2928,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.855005",
+        "dc:date": "2020-08-17T22:41:50.048108",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0022"
@@ -2939,7 +2939,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.855763",
+        "dc:date": "2020-08-17T22:41:50.049178",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0023"
@@ -2950,7 +2950,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.856373",
+        "dc:date": "2020-08-17T22:41:50.050057",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0024"
@@ -2961,7 +2961,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.85694",
+        "dc:date": "2020-08-17T22:41:50.050954",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0025"
@@ -2972,7 +2972,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.857439",
+        "dc:date": "2020-08-17T22:41:50.05176",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0027"
@@ -2983,7 +2983,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.857928",
+        "dc:date": "2020-08-17T22:41:50.052557",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0028"
@@ -2994,7 +2994,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.858529",
+        "dc:date": "2020-08-17T22:41:50.053477",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0029"
@@ -3005,7 +3005,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.859014",
+        "dc:date": "2020-08-17T22:41:50.054159",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0030"
@@ -3016,7 +3016,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.8596",
+        "dc:date": "2020-08-17T22:41:50.054884",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0031"
@@ -3027,7 +3027,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.860044",
+        "dc:date": "2020-08-17T22:41:50.055397",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0032"
@@ -3038,7 +3038,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.860545",
+        "dc:date": "2020-08-17T22:41:50.055976",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0033"
@@ -3049,7 +3049,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.861078",
+        "dc:date": "2020-08-17T22:41:50.056527",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0034"
@@ -3060,7 +3060,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.861591",
+        "dc:date": "2020-08-17T22:41:50.057044",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0035"
@@ -3071,7 +3071,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.862337",
+        "dc:date": "2020-08-17T22:41:50.057754",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0036"
@@ -3082,7 +3082,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.863068",
+        "dc:date": "2020-08-17T22:41:50.058217",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0037"
@@ -3093,7 +3093,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.864364",
+        "dc:date": "2020-08-17T22:41:50.058703",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0039"
@@ -3104,7 +3104,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.864891",
+        "dc:date": "2020-08-17T22:41:50.059182",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0040"
@@ -3115,7 +3115,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.865515",
+        "dc:date": "2020-08-17T22:41:50.059646",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0041"
@@ -3126,7 +3126,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.866114",
+        "dc:date": "2020-08-17T22:41:50.060167",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0042"
@@ -3137,7 +3137,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.866618",
+        "dc:date": "2020-08-17T22:41:50.060639",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0043"
@@ -3148,7 +3148,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.867134",
+        "dc:date": "2020-08-17T22:41:50.061153",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0044"
@@ -3159,7 +3159,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.867647",
+        "dc:date": "2020-08-17T22:41:50.061536",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0045"
@@ -3170,7 +3170,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.86805",
+        "dc:date": "2020-08-17T22:41:50.061969",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0046"
@@ -3181,7 +3181,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.868534",
+        "dc:date": "2020-08-17T22:41:50.062484",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0047"
@@ -3192,7 +3192,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.869096",
+        "dc:date": "2020-08-17T22:41:50.063538",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0048"
@@ -3203,7 +3203,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.869621",
+        "dc:date": "2020-08-17T22:41:50.064049",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0049"
@@ -3214,7 +3214,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.870093",
+        "dc:date": "2020-08-17T22:41:50.064476",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0050"
@@ -3225,7 +3225,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.870601",
+        "dc:date": "2020-08-17T22:41:50.064917",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0051"
@@ -3236,7 +3236,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.871063",
+        "dc:date": "2020-08-17T22:41:50.065404",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0052"
@@ -3247,7 +3247,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.871491",
+        "dc:date": "2020-08-17T22:41:50.065913",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0053"
@@ -3258,7 +3258,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.871984",
+        "dc:date": "2020-08-17T22:41:50.066363",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0054"
@@ -3269,7 +3269,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.872406",
+        "dc:date": "2020-08-17T22:41:50.066849",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0055"
@@ -3280,7 +3280,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.873403",
+        "dc:date": "2020-08-17T22:41:50.067384",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0056"
@@ -3291,7 +3291,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.873987",
+        "dc:date": "2020-08-17T22:41:50.067804",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0057"
@@ -3302,7 +3302,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.874453",
+        "dc:date": "2020-08-17T22:41:50.068261",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0058"
@@ -3313,7 +3313,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.87496",
+        "dc:date": "2020-08-17T22:41:50.068719",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0059"
@@ -3324,7 +3324,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.8755",
+        "dc:date": "2020-08-17T22:41:50.069208",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0060"
@@ -3335,7 +3335,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.87598",
+        "dc:date": "2020-08-17T22:41:50.069661",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0061"
@@ -3346,7 +3346,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.876649",
+        "dc:date": "2020-08-17T22:41:50.070286",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0062"
@@ -3357,7 +3357,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.877275",
+        "dc:date": "2020-08-17T22:41:50.070767",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0063"
@@ -3368,7 +3368,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.877796",
+        "dc:date": "2020-08-17T22:41:50.07125",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0064"
@@ -3379,7 +3379,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.87832",
+        "dc:date": "2020-08-17T22:41:50.071726",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0065"
@@ -3390,7 +3390,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.878905",
+        "dc:date": "2020-08-17T22:41:50.072234",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0066"
@@ -3401,7 +3401,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.879539",
+        "dc:date": "2020-08-17T22:41:50.072677",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0067"
@@ -3412,7 +3412,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.880259",
+        "dc:date": "2020-08-17T22:41:50.073149",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0068"
@@ -3423,7 +3423,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.880719",
+        "dc:date": "2020-08-17T22:41:50.073589",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0069"
@@ -3434,7 +3434,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.881251",
+        "dc:date": "2020-08-17T22:41:50.074006",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0070"
@@ -3445,7 +3445,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.881798",
+        "dc:date": "2020-08-17T22:41:50.074457",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0072"
@@ -3456,7 +3456,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.88225",
+        "dc:date": "2020-08-17T22:41:50.07496",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0073"
@@ -3467,7 +3467,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.882822",
+        "dc:date": "2020-08-17T22:41:50.075446",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0074"
@@ -3478,7 +3478,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.883235",
+        "dc:date": "2020-08-17T22:41:50.075851",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0075"
@@ -3489,7 +3489,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.883696",
+        "dc:date": "2020-08-17T22:41:50.076264",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0076"
@@ -3500,7 +3500,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.884451",
+        "dc:date": "2020-08-17T22:41:50.077072",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0077"
@@ -3511,7 +3511,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.88516",
+        "dc:date": "2020-08-17T22:41:50.077749",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0078"
@@ -3522,7 +3522,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.885697",
+        "dc:date": "2020-08-17T22:41:50.07833",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0079"
@@ -3533,7 +3533,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.886359",
+        "dc:date": "2020-08-17T22:41:50.078876",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0080"
@@ -3544,7 +3544,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.886804",
+        "dc:date": "2020-08-17T22:41:50.07936",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0081"
@@ -3555,7 +3555,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.887307",
+        "dc:date": "2020-08-17T22:41:50.07982",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0082"
@@ -3566,7 +3566,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.887763",
+        "dc:date": "2020-08-17T22:41:50.080318",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0083"
@@ -3577,7 +3577,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.888218",
+        "dc:date": "2020-08-17T22:41:50.080752",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0084"
@@ -3588,7 +3588,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.888678",
+        "dc:date": "2020-08-17T22:41:50.081205",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0085"
@@ -3599,7 +3599,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.889159",
+        "dc:date": "2020-08-17T22:41:50.08176",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0086"
@@ -3610,7 +3610,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.889688",
+        "dc:date": "2020-08-17T22:41:50.082286",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0087"
@@ -3621,7 +3621,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.890155",
+        "dc:date": "2020-08-17T22:41:50.082796",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0088"
@@ -3632,7 +3632,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.890597",
+        "dc:date": "2020-08-17T22:41:50.083247",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0089"
@@ -3643,7 +3643,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.891041",
+        "dc:date": "2020-08-17T22:41:50.083643",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0090"
@@ -3654,7 +3654,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.891479",
+        "dc:date": "2020-08-17T22:41:50.084093",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0091"
@@ -3665,7 +3665,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.89202",
+        "dc:date": "2020-08-17T22:41:50.0847",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0092"
@@ -3676,7 +3676,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.892544",
+        "dc:date": "2020-08-17T22:41:50.085212",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0093"
@@ -3687,7 +3687,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.893026",
+        "dc:date": "2020-08-17T22:41:50.085689",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0094"
@@ -3698,7 +3698,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.893503",
+        "dc:date": "2020-08-17T22:41:50.086137",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0095"
@@ -3709,7 +3709,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.893969",
+        "dc:date": "2020-08-17T22:41:50.086609",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0096"
@@ -3720,7 +3720,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.894536",
+        "dc:date": "2020-08-17T22:41:50.08704",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0097"
@@ -3731,7 +3731,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.895917",
+        "dc:date": "2020-08-17T22:41:50.087455",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0098"
@@ -3742,7 +3742,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.896446",
+        "dc:date": "2020-08-17T22:41:50.087907",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0099"
@@ -3753,7 +3753,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.896937",
+        "dc:date": "2020-08-17T22:41:50.088696",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0100"
@@ -3764,7 +3764,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.897379",
+        "dc:date": "2020-08-17T22:41:50.089157",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0101"
@@ -3775,7 +3775,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.897837",
+        "dc:date": "2020-08-17T22:41:50.089627",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0102"
@@ -3786,7 +3786,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.898276",
+        "dc:date": "2020-08-17T22:41:50.090101",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0103"
@@ -3797,7 +3797,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.898779",
+        "dc:date": "2020-08-17T22:41:50.090522",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0104"
@@ -3808,7 +3808,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.899298",
+        "dc:date": "2020-08-17T22:41:50.091005",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0105"
@@ -3819,7 +3819,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.899767",
+        "dc:date": "2020-08-17T22:41:50.091487",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0106"
@@ -3830,7 +3830,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.90029",
+        "dc:date": "2020-08-17T22:41:50.09193",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0107"
@@ -3841,7 +3841,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.900793",
+        "dc:date": "2020-08-17T22:41:50.092413",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0108"
@@ -3852,7 +3852,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.901271",
+        "dc:date": "2020-08-17T22:41:50.092862",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0109"
@@ -3863,7 +3863,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.902242",
+        "dc:date": "2020-08-17T22:41:50.093348",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0110"
@@ -3874,7 +3874,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.902814",
+        "dc:date": "2020-08-17T22:41:50.093858",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0111"
@@ -3885,7 +3885,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.903324",
+        "dc:date": "2020-08-17T22:41:50.094352",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0112"
@@ -3896,7 +3896,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.903803",
+        "dc:date": "2020-08-17T22:41:50.094788",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0113"
@@ -3907,7 +3907,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.904251",
+        "dc:date": "2020-08-17T22:41:50.09525",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0114"
@@ -3918,7 +3918,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.904688",
+        "dc:date": "2020-08-17T22:41:50.09569",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0117"
@@ -3929,7 +3929,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.90519",
+        "dc:date": "2020-08-17T22:41:50.096165",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0118"
@@ -3940,7 +3940,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.905778",
+        "dc:date": "2020-08-17T22:41:50.096728",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0119"
@@ -3951,7 +3951,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.906208",
+        "dc:date": "2020-08-17T22:41:50.097231",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0120"
@@ -3962,7 +3962,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.906625",
+        "dc:date": "2020-08-17T22:41:50.09754",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0121"
@@ -3973,7 +3973,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.906633",
+        "dc:date": "2020-08-17T22:41:50.097548",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0122"
@@ -3984,7 +3984,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.906636",
+        "dc:date": "2020-08-17T22:41:50.097551",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0123"
@@ -3995,7 +3995,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.907091",
+        "dc:date": "2020-08-17T22:41:50.098041",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0124"
@@ -4006,7 +4006,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.907513",
+        "dc:date": "2020-08-17T22:41:50.098511",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0125"
@@ -4017,7 +4017,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.908565",
+        "dc:date": "2020-08-17T22:41:50.099702",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0126"
@@ -4028,7 +4028,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.910211",
+        "dc:date": "2020-08-17T22:41:50.101187",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0127"
@@ -4039,7 +4039,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.912276",
+        "dc:date": "2020-08-17T22:41:50.102854",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0128"
@@ -4050,7 +4050,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.912695",
+        "dc:date": "2020-08-17T22:41:50.103274",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0129"
@@ -4061,7 +4061,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.913099",
+        "dc:date": "2020-08-17T22:41:50.103738",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#t0130"
@@ -4072,7 +4072,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.913601",
+        "dc:date": "2020-08-17T22:41:50.104301",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc001"
@@ -4083,7 +4083,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.91406",
+        "dc:date": "2020-08-17T22:41:50.104759",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc002"
@@ -4094,7 +4094,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.914555",
+        "dc:date": "2020-08-17T22:41:50.105249",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc003"
@@ -4105,7 +4105,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.915072",
+        "dc:date": "2020-08-17T22:41:50.105696",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc004"
@@ -4116,7 +4116,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.915551",
+        "dc:date": "2020-08-17T22:41:50.106241",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc005"
@@ -4127,7 +4127,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.916059",
+        "dc:date": "2020-08-17T22:41:50.106698",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc006"
@@ -4138,7 +4138,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.916602",
+        "dc:date": "2020-08-17T22:41:50.107136",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc007"
@@ -4149,7 +4149,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.9171",
+        "dc:date": "2020-08-17T22:41:50.107602",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc008"
@@ -4160,7 +4160,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.917587",
+        "dc:date": "2020-08-17T22:41:50.108056",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc009"
@@ -4171,7 +4171,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.918069",
+        "dc:date": "2020-08-17T22:41:50.108528",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc010"
@@ -4182,7 +4182,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.918493",
+        "dc:date": "2020-08-17T22:41:50.108993",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc011"
@@ -4193,7 +4193,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.919028",
+        "dc:date": "2020-08-17T22:41:50.109441",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc012"
@@ -4204,7 +4204,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.919613",
+        "dc:date": "2020-08-17T22:41:50.109993",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc013"
@@ -4215,7 +4215,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.920076",
+        "dc:date": "2020-08-17T22:41:50.110479",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc014"
@@ -4226,7 +4226,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.92064",
+        "dc:date": "2020-08-17T22:41:50.111034",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc015"
@@ -4237,7 +4237,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.921088",
+        "dc:date": "2020-08-17T22:41:50.111469",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc016"
@@ -4248,7 +4248,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.921502",
+        "dc:date": "2020-08-17T22:41:50.111894",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc017"
@@ -4259,7 +4259,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.921853",
+        "dc:date": "2020-08-17T22:41:50.112355",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc018"
@@ -4270,7 +4270,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.922357",
+        "dc:date": "2020-08-17T22:41:50.112827",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc019"
@@ -4281,7 +4281,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.922723",
+        "dc:date": "2020-08-17T22:41:50.11326",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc020"
@@ -4292,7 +4292,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.92327",
+        "dc:date": "2020-08-17T22:41:50.113786",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc021"
@@ -4303,7 +4303,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.923641",
+        "dc:date": "2020-08-17T22:41:50.114608",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc022"
@@ -4314,7 +4314,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.924085",
+        "dc:date": "2020-08-17T22:41:50.115055",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc023"
@@ -4325,7 +4325,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.924628",
+        "dc:date": "2020-08-17T22:41:50.115551",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc024"
@@ -4336,7 +4336,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.925011",
+        "dc:date": "2020-08-17T22:41:50.115992",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc025"
@@ -4347,7 +4347,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.925434",
+        "dc:date": "2020-08-17T22:41:50.116379",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc026"
@@ -4358,7 +4358,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.925848",
+        "dc:date": "2020-08-17T22:41:50.116734",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc027"
@@ -4369,7 +4369,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.926152",
+        "dc:date": "2020-08-17T22:41:50.117084",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc028"
@@ -4380,7 +4380,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.926351",
+        "dc:date": "2020-08-17T22:41:50.117289",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc029"
@@ -4391,7 +4391,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.926554",
+        "dc:date": "2020-08-17T22:41:50.117523",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc030"
@@ -4402,7 +4402,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.92656",
+        "dc:date": "2020-08-17T22:41:50.117529",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc031"
@@ -4413,7 +4413,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.926569",
+        "dc:date": "2020-08-17T22:41:50.117532",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc032"
@@ -4424,7 +4424,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.926573",
+        "dc:date": "2020-08-17T22:41:50.117535",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc033"
@@ -4435,7 +4435,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.927367",
+        "dc:date": "2020-08-17T22:41:50.118352",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc034"
@@ -4446,7 +4446,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.928",
+        "dc:date": "2020-08-17T22:41:50.118865",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tc035"
@@ -4457,7 +4457,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.928789",
+        "dc:date": "2020-08-17T22:41:50.119335",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi01"
@@ -4468,7 +4468,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.929386",
+        "dc:date": "2020-08-17T22:41:50.119912",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi02"
@@ -4479,7 +4479,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.9299",
+        "dc:date": "2020-08-17T22:41:50.120435",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi03"
@@ -4490,7 +4490,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.930414",
+        "dc:date": "2020-08-17T22:41:50.120976",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi04"
@@ -4501,7 +4501,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.930911",
+        "dc:date": "2020-08-17T22:41:50.121544",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi05"
@@ -4512,7 +4512,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.93143",
+        "dc:date": "2020-08-17T22:41:50.122034",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi06"
@@ -4523,7 +4523,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.932187",
+        "dc:date": "2020-08-17T22:41:50.122519",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi07"
@@ -4534,7 +4534,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.932451",
+        "dc:date": "2020-08-17T22:41:50.122841",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi08"
@@ -4545,7 +4545,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.932723",
+        "dc:date": "2020-08-17T22:41:50.123097",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tdi09"
@@ -4556,7 +4556,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.933025",
+        "dc:date": "2020-08-17T22:41:50.123446",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tec01"
@@ -4567,7 +4567,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.933032",
+        "dc:date": "2020-08-17T22:41:50.123453",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tec02"
@@ -4578,7 +4578,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.933296",
+        "dc:date": "2020-08-17T22:41:50.123739",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tem01"
@@ -4589,7 +4589,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.933617",
+        "dc:date": "2020-08-17T22:41:50.124048",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ten01"
@@ -4600,7 +4600,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.933901",
+        "dc:date": "2020-08-17T22:41:50.124316",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ten02"
@@ -4611,7 +4611,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.934205",
+        "dc:date": "2020-08-17T22:41:50.124572",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ten03"
@@ -4622,7 +4622,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.934511",
+        "dc:date": "2020-08-17T22:41:50.124881",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ten04"
@@ -4633,7 +4633,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.934847",
+        "dc:date": "2020-08-17T22:41:50.125138",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ten05"
@@ -4644,7 +4644,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.935119",
+        "dc:date": "2020-08-17T22:41:50.12541",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ten06"
@@ -4655,7 +4655,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.935393",
+        "dc:date": "2020-08-17T22:41:50.125673",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tep02"
@@ -4666,7 +4666,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.935649",
+        "dc:date": "2020-08-17T22:41:50.125971",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tep03"
@@ -4677,7 +4677,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.935919",
+        "dc:date": "2020-08-17T22:41:50.126209",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter01"
@@ -4688,7 +4688,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.936159",
+        "dc:date": "2020-08-17T22:41:50.12646",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter04"
@@ -4699,7 +4699,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.936512",
+        "dc:date": "2020-08-17T22:41:50.126866",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter05"
@@ -4710,7 +4710,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.93675",
+        "dc:date": "2020-08-17T22:41:50.127116",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter06"
@@ -4721,7 +4721,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.936982",
+        "dc:date": "2020-08-17T22:41:50.12738",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter07"
@@ -4732,7 +4732,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.937255",
+        "dc:date": "2020-08-17T22:41:50.127635",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter08"
@@ -4743,7 +4743,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.937511",
+        "dc:date": "2020-08-17T22:41:50.127873",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter09"
@@ -4754,7 +4754,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.938019",
+        "dc:date": "2020-08-17T22:41:50.128118",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter10"
@@ -4765,7 +4765,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.938228",
+        "dc:date": "2020-08-17T22:41:50.128282",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter11"
@@ -4776,7 +4776,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.938433",
+        "dc:date": "2020-08-17T22:41:50.128479",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter12"
@@ -4787,7 +4787,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.938645",
+        "dc:date": "2020-08-17T22:41:50.128749",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter13"
@@ -4798,7 +4798,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.938885",
+        "dc:date": "2020-08-17T22:41:50.128968",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter14"
@@ -4809,7 +4809,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.939183",
+        "dc:date": "2020-08-17T22:41:50.129293",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter15"
@@ -4820,7 +4820,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.939435",
+        "dc:date": "2020-08-17T22:41:50.129569",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter17"
@@ -4831,7 +4831,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.939738",
+        "dc:date": "2020-08-17T22:41:50.12989",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter18"
@@ -4842,7 +4842,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.940007",
+        "dc:date": "2020-08-17T22:41:50.130157",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter19"
@@ -4853,7 +4853,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.940244",
+        "dc:date": "2020-08-17T22:41:50.130409",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter20"
@@ -4864,7 +4864,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.940591",
+        "dc:date": "2020-08-17T22:41:50.13071",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter21"
@@ -4875,7 +4875,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.941445",
+        "dc:date": "2020-08-17T22:41:50.131016",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter22"
@@ -4886,7 +4886,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.941876",
+        "dc:date": "2020-08-17T22:41:50.131281",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter23"
@@ -4897,7 +4897,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.942097",
+        "dc:date": "2020-08-17T22:41:50.131586",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter25"
@@ -4908,7 +4908,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.942336",
+        "dc:date": "2020-08-17T22:41:50.13186",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter26"
@@ -4919,7 +4919,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.942617",
+        "dc:date": "2020-08-17T22:41:50.132141",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter27"
@@ -4930,7 +4930,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.942851",
+        "dc:date": "2020-08-17T22:41:50.132385",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter28"
@@ -4941,7 +4941,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.94312",
+        "dc:date": "2020-08-17T22:41:50.132649",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter29"
@@ -4952,7 +4952,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.943392",
+        "dc:date": "2020-08-17T22:41:50.132922",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter30"
@@ -4963,7 +4963,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.943683",
+        "dc:date": "2020-08-17T22:41:50.133165",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter31"
@@ -4974,7 +4974,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.943914",
+        "dc:date": "2020-08-17T22:41:50.133482",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter33"
@@ -4985,7 +4985,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.944224",
+        "dc:date": "2020-08-17T22:41:50.133798",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter34"
@@ -4996,7 +4996,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.944519",
+        "dc:date": "2020-08-17T22:41:50.134146",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter35"
@@ -5007,7 +5007,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.9448",
+        "dc:date": "2020-08-17T22:41:50.134424",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter36"
@@ -5018,7 +5018,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.945027",
+        "dc:date": "2020-08-17T22:41:50.134757",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter37"
@@ -5029,7 +5029,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.945269",
+        "dc:date": "2020-08-17T22:41:50.135003",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter38"
@@ -5040,7 +5040,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.945517",
+        "dc:date": "2020-08-17T22:41:50.135245",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter39"
@@ -5051,7 +5051,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.945737",
+        "dc:date": "2020-08-17T22:41:50.135551",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter40"
@@ -5062,7 +5062,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.945968",
+        "dc:date": "2020-08-17T22:41:50.135831",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter41"
@@ -5073,7 +5073,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.946226",
+        "dc:date": "2020-08-17T22:41:50.136139",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter42"
@@ -5084,7 +5084,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.946513",
+        "dc:date": "2020-08-17T22:41:50.136409",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter43"
@@ -5095,7 +5095,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.946808",
+        "dc:date": "2020-08-17T22:41:50.136775",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter44"
@@ -5106,7 +5106,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.94713",
+        "dc:date": "2020-08-17T22:41:50.137059",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter48"
@@ -5117,7 +5117,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.947447",
+        "dc:date": "2020-08-17T22:41:50.137456",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter49"
@@ -5128,7 +5128,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.94768",
+        "dc:date": "2020-08-17T22:41:50.137666",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter50"
@@ -5139,7 +5139,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.947919",
+        "dc:date": "2020-08-17T22:41:50.137962",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter51"
@@ -5150,7 +5150,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.947927",
+        "dc:date": "2020-08-17T22:41:50.13797",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter52"
@@ -5161,7 +5161,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.948196",
+        "dc:date": "2020-08-17T22:41:50.138278",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ter53"
@@ -5172,7 +5172,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.94851",
+        "dc:date": "2020-08-17T22:41:50.138575",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tes01"
@@ -5183,7 +5183,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.94882",
+        "dc:date": "2020-08-17T22:41:50.13884",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tes02"
@@ -5194,7 +5194,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.949242",
+        "dc:date": "2020-08-17T22:41:50.139278",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin01"
@@ -5205,7 +5205,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.949715",
+        "dc:date": "2020-08-17T22:41:50.139715",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin02"
@@ -5216,7 +5216,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.950131",
+        "dc:date": "2020-08-17T22:41:50.140253",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin03"
@@ -5227,7 +5227,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.950595",
+        "dc:date": "2020-08-17T22:41:50.140724",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin04"
@@ -5238,7 +5238,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.951067",
+        "dc:date": "2020-08-17T22:41:50.141159",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin05"
@@ -5249,7 +5249,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.951868",
+        "dc:date": "2020-08-17T22:41:50.14192",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin06"
@@ -5260,7 +5260,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.952147",
+        "dc:date": "2020-08-17T22:41:50.142203",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin07"
@@ -5271,7 +5271,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.952402",
+        "dc:date": "2020-08-17T22:41:50.142425",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin08"
@@ -5282,7 +5282,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.952691",
+        "dc:date": "2020-08-17T22:41:50.142652",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tin09"
@@ -5293,7 +5293,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.953296",
+        "dc:date": "2020-08-17T22:41:50.143149",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs01"
@@ -5304,7 +5304,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.953775",
+        "dc:date": "2020-08-17T22:41:50.144092",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs02"
@@ -5315,7 +5315,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.954197",
+        "dc:date": "2020-08-17T22:41:50.144621",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs03"
@@ -5326,7 +5326,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.95468",
+        "dc:date": "2020-08-17T22:41:50.14512",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs04"
@@ -5337,7 +5337,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.95517",
+        "dc:date": "2020-08-17T22:41:50.145616",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs05"
@@ -5348,7 +5348,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.955616",
+        "dc:date": "2020-08-17T22:41:50.146106",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs06"
@@ -5359,7 +5359,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.955979",
+        "dc:date": "2020-08-17T22:41:50.146439",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs07"
@@ -5370,7 +5370,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.956394",
+        "dc:date": "2020-08-17T22:41:50.14681",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs08"
@@ -5381,7 +5381,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.956763",
+        "dc:date": "2020-08-17T22:41:50.147193",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs09"
@@ -5392,7 +5392,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.957177",
+        "dc:date": "2020-08-17T22:41:50.147511",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs10"
@@ -5403,7 +5403,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.957633",
+        "dc:date": "2020-08-17T22:41:50.147995",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs11"
@@ -5414,7 +5414,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.958261",
+        "dc:date": "2020-08-17T22:41:50.148536",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs12"
@@ -5425,7 +5425,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.959232",
+        "dc:date": "2020-08-17T22:41:50.149067",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs13"
@@ -5436,7 +5436,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.959792",
+        "dc:date": "2020-08-17T22:41:50.149544",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs14"
@@ -5447,7 +5447,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.960185",
+        "dc:date": "2020-08-17T22:41:50.149998",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs15"
@@ -5458,7 +5458,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.960615",
+        "dc:date": "2020-08-17T22:41:50.150547",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs16"
@@ -5469,7 +5469,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.961111",
+        "dc:date": "2020-08-17T22:41:50.150989",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs17"
@@ -5480,7 +5480,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.961702",
+        "dc:date": "2020-08-17T22:41:50.151476",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs18"
@@ -5491,7 +5491,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.962159",
+        "dc:date": "2020-08-17T22:41:50.151916",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs19"
@@ -5502,7 +5502,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.962515",
+        "dc:date": "2020-08-17T22:41:50.152272",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs20"
@@ -5513,7 +5513,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.962798",
+        "dc:date": "2020-08-17T22:41:50.152542",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs21"
@@ -5524,7 +5524,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.963141",
+        "dc:date": "2020-08-17T22:41:50.152855",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs22"
@@ -5535,7 +5535,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.963451",
+        "dc:date": "2020-08-17T22:41:50.153131",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tjs23"
@@ -5546,7 +5546,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.963965",
+        "dc:date": "2020-08-17T22:41:50.15357",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tl001"
@@ -5557,7 +5557,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.964397",
+        "dc:date": "2020-08-17T22:41:50.153995",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli01"
@@ -5568,7 +5568,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.964836",
+        "dc:date": "2020-08-17T22:41:50.154492",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli02"
@@ -5579,7 +5579,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.965305",
+        "dc:date": "2020-08-17T22:41:50.154943",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli03"
@@ -5590,7 +5590,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.965758",
+        "dc:date": "2020-08-17T22:41:50.155456",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli04"
@@ -5601,7 +5601,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.966226",
+        "dc:date": "2020-08-17T22:41:50.155939",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli05"
@@ -5612,7 +5612,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.966654",
+        "dc:date": "2020-08-17T22:41:50.156392",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli06"
@@ -5623,7 +5623,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.967113",
+        "dc:date": "2020-08-17T22:41:50.156834",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli07"
@@ -5634,7 +5634,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.967562",
+        "dc:date": "2020-08-17T22:41:50.157335",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli08"
@@ -5645,7 +5645,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.968006",
+        "dc:date": "2020-08-17T22:41:50.157799",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli09"
@@ -5656,7 +5656,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.968462",
+        "dc:date": "2020-08-17T22:41:50.158272",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tli10"
@@ -5667,7 +5667,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.968944",
+        "dc:date": "2020-08-17T22:41:50.15872",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm001"
@@ -5678,7 +5678,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.969446",
+        "dc:date": "2020-08-17T22:41:50.159199",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm002"
@@ -5689,7 +5689,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.969938",
+        "dc:date": "2020-08-17T22:41:50.159704",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm003"
@@ -5700,7 +5700,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.970423",
+        "dc:date": "2020-08-17T22:41:50.160206",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm004"
@@ -5711,7 +5711,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.970947",
+        "dc:date": "2020-08-17T22:41:50.160642",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm005"
@@ -5722,7 +5722,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.971437",
+        "dc:date": "2020-08-17T22:41:50.161133",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm006"
@@ -5733,7 +5733,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.972025",
+        "dc:date": "2020-08-17T22:41:50.161614",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm007"
@@ -5744,7 +5744,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.972678",
+        "dc:date": "2020-08-17T22:41:50.162078",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm008"
@@ -5755,7 +5755,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.974107",
+        "dc:date": "2020-08-17T22:41:50.162598",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm009"
@@ -5766,7 +5766,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.974707",
+        "dc:date": "2020-08-17T22:41:50.163154",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm010"
@@ -5777,7 +5777,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.975156",
+        "dc:date": "2020-08-17T22:41:50.16361",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm011"
@@ -5788,7 +5788,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.97561",
+        "dc:date": "2020-08-17T22:41:50.164052",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm012"
@@ -5799,7 +5799,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.976007",
+        "dc:date": "2020-08-17T22:41:50.164517",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm013"
@@ -5810,7 +5810,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.976512",
+        "dc:date": "2020-08-17T22:41:50.164972",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm014"
@@ -5821,7 +5821,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.976946",
+        "dc:date": "2020-08-17T22:41:50.165485",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm015"
@@ -5832,7 +5832,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.977466",
+        "dc:date": "2020-08-17T22:41:50.165986",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm016"
@@ -5843,7 +5843,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.977915",
+        "dc:date": "2020-08-17T22:41:50.166457",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm017"
@@ -5854,7 +5854,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.978333",
+        "dc:date": "2020-08-17T22:41:50.166971",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm018"
@@ -5865,7 +5865,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.978834",
+        "dc:date": "2020-08-17T22:41:50.167398",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm019"
@@ -5876,7 +5876,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.979059",
+        "dc:date": "2020-08-17T22:41:50.167623",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tm020"
@@ -5887,7 +5887,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.979501",
+        "dc:date": "2020-08-17T22:41:50.168051",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn001"
@@ -5898,7 +5898,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.979975",
+        "dc:date": "2020-08-17T22:41:50.168486",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn002"
@@ -5909,7 +5909,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.980417",
+        "dc:date": "2020-08-17T22:41:50.168933",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn003"
@@ -5920,7 +5920,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.980943",
+        "dc:date": "2020-08-17T22:41:50.169398",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn004"
@@ -5931,7 +5931,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.98143",
+        "dc:date": "2020-08-17T22:41:50.169859",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn005"
@@ -5942,7 +5942,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.981875",
+        "dc:date": "2020-08-17T22:41:50.170303",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn006"
@@ -5953,7 +5953,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.982395",
+        "dc:date": "2020-08-17T22:41:50.170757",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn007"
@@ -5964,7 +5964,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.982856",
+        "dc:date": "2020-08-17T22:41:50.171227",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tn008"
@@ -5975,7 +5975,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.983261",
+        "dc:date": "2020-08-17T22:41:50.17169",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tp001"
@@ -5986,7 +5986,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.983723",
+        "dc:date": "2020-08-17T22:41:50.172138",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tp002"
@@ -5997,7 +5997,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.984221",
+        "dc:date": "2020-08-17T22:41:50.1726",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tp003"
@@ -6008,7 +6008,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.984691",
+        "dc:date": "2020-08-17T22:41:50.173057",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tp004"
@@ -6019,7 +6019,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.984987",
+        "dc:date": "2020-08-17T22:41:50.173319",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi01"
@@ -6030,7 +6030,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.98523",
+        "dc:date": "2020-08-17T22:41:50.17358",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi02"
@@ -6041,7 +6041,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.985581",
+        "dc:date": "2020-08-17T22:41:50.173875",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi03"
@@ -6052,7 +6052,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.98589",
+        "dc:date": "2020-08-17T22:41:50.174144",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi04"
@@ -6063,7 +6063,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.986226",
+        "dc:date": "2020-08-17T22:41:50.174435",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi05"
@@ -6074,7 +6074,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.986906",
+        "dc:date": "2020-08-17T22:41:50.174923",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi06"
@@ -6085,7 +6085,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.987757",
+        "dc:date": "2020-08-17T22:41:50.175872",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi07"
@@ -6096,7 +6096,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.989011",
+        "dc:date": "2020-08-17T22:41:50.176656",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi08"
@@ -6107,7 +6107,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.989505",
+        "dc:date": "2020-08-17T22:41:50.177159",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi09"
@@ -6118,7 +6118,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.990058",
+        "dc:date": "2020-08-17T22:41:50.177759",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi10"
@@ -6129,7 +6129,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.990444",
+        "dc:date": "2020-08-17T22:41:50.178184",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpi11"
@@ -6140,7 +6140,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.99071",
+        "dc:date": "2020-08-17T22:41:50.178461",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr01"
@@ -6151,7 +6151,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.991129",
+        "dc:date": "2020-08-17T22:41:50.178845",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr02"
@@ -6162,7 +6162,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.991678",
+        "dc:date": "2020-08-17T22:41:50.179121",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr03"
@@ -6173,7 +6173,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.992229",
+        "dc:date": "2020-08-17T22:41:50.179445",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr04"
@@ -6184,7 +6184,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.992513",
+        "dc:date": "2020-08-17T22:41:50.179687",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr05"
@@ -6195,7 +6195,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.992842",
+        "dc:date": "2020-08-17T22:41:50.180114",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr06"
@@ -6206,7 +6206,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.99322",
+        "dc:date": "2020-08-17T22:41:50.180435",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr08"
@@ -6217,7 +6217,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.993461",
+        "dc:date": "2020-08-17T22:41:50.180799",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr09"
@@ -6228,7 +6228,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.993818",
+        "dc:date": "2020-08-17T22:41:50.181193",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr10"
@@ -6239,7 +6239,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.994063",
+        "dc:date": "2020-08-17T22:41:50.181434",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr11"
@@ -6250,7 +6250,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.994345",
+        "dc:date": "2020-08-17T22:41:50.181703",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr12"
@@ -6261,7 +6261,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.994783",
+        "dc:date": "2020-08-17T22:41:50.182096",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr13"
@@ -6272,7 +6272,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.99517",
+        "dc:date": "2020-08-17T22:41:50.182507",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr14"
@@ -6283,7 +6283,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.99558",
+        "dc:date": "2020-08-17T22:41:50.182877",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr15"
@@ -6294,7 +6294,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.99597",
+        "dc:date": "2020-08-17T22:41:50.183365",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr16"
@@ -6305,7 +6305,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.996265",
+        "dc:date": "2020-08-17T22:41:50.183646",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr17"
@@ -6316,7 +6316,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.996517",
+        "dc:date": "2020-08-17T22:41:50.183969",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr18"
@@ -6327,7 +6327,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.996918",
+        "dc:date": "2020-08-17T22:41:50.184478",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr19"
@@ -6338,7 +6338,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.997202",
+        "dc:date": "2020-08-17T22:41:50.184747",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr20"
@@ -6349,7 +6349,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.997483",
+        "dc:date": "2020-08-17T22:41:50.185047",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr21"
@@ -6360,7 +6360,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.99782",
+        "dc:date": "2020-08-17T22:41:50.185427",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr22"
@@ -6371,7 +6371,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.998135",
+        "dc:date": "2020-08-17T22:41:50.185829",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr23"
@@ -6382,7 +6382,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.998533",
+        "dc:date": "2020-08-17T22:41:50.18636",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr24"
@@ -6393,7 +6393,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.999412",
+        "dc:date": "2020-08-17T22:41:50.187178",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr25"
@@ -6404,7 +6404,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:22.999873",
+        "dc:date": "2020-08-17T22:41:50.187685",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr26"
@@ -6415,7 +6415,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.000405",
+        "dc:date": "2020-08-17T22:41:50.188184",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr27"
@@ -6426,7 +6426,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.000412",
+        "dc:date": "2020-08-17T22:41:50.188192",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr28"
@@ -6437,7 +6437,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.000928",
+        "dc:date": "2020-08-17T22:41:50.188686",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr29"
@@ -6448,7 +6448,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.001423",
+        "dc:date": "2020-08-17T22:41:50.189184",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr30"
@@ -6459,7 +6459,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.001772",
+        "dc:date": "2020-08-17T22:41:50.189507",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr31"
@@ -6470,7 +6470,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.002119",
+        "dc:date": "2020-08-17T22:41:50.18982",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr32"
@@ -6481,7 +6481,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.002394",
+        "dc:date": "2020-08-17T22:41:50.190114",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr33"
@@ -6492,7 +6492,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.002711",
+        "dc:date": "2020-08-17T22:41:50.190552",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr34"
@@ -6503,7 +6503,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.002983",
+        "dc:date": "2020-08-17T22:41:50.190879",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr35"
@@ -6514,7 +6514,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.003337",
+        "dc:date": "2020-08-17T22:41:50.191186",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr36"
@@ -6525,7 +6525,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.003647",
+        "dc:date": "2020-08-17T22:41:50.191478",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr37"
@@ -6536,7 +6536,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.003654",
+        "dc:date": "2020-08-17T22:41:50.191486",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr38"
@@ -6547,7 +6547,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.003657",
+        "dc:date": "2020-08-17T22:41:50.191489",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr39"
@@ -6558,7 +6558,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.004038",
+        "dc:date": "2020-08-17T22:41:50.191843",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tpr40"
@@ -6569,7 +6569,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.004227",
+        "dc:date": "2020-08-17T22:41:50.192041",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso01"
@@ -6580,7 +6580,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.004446",
+        "dc:date": "2020-08-17T22:41:50.192248",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso02"
@@ -6591,7 +6591,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.004805",
+        "dc:date": "2020-08-17T22:41:50.192576",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso03"
@@ -6602,7 +6602,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.005749",
+        "dc:date": "2020-08-17T22:41:50.193175",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso05"
@@ -6613,7 +6613,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.006621",
+        "dc:date": "2020-08-17T22:41:50.194073",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso06"
@@ -6624,7 +6624,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.007161",
+        "dc:date": "2020-08-17T22:41:50.194668",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso07"
@@ -6635,7 +6635,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.007863",
+        "dc:date": "2020-08-17T22:41:50.195359",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso08"
@@ -6646,7 +6646,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.008482",
+        "dc:date": "2020-08-17T22:41:50.196107",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso09"
@@ -6657,7 +6657,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.009042",
+        "dc:date": "2020-08-17T22:41:50.197063",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso10"
@@ -6668,7 +6668,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.009655",
+        "dc:date": "2020-08-17T22:41:50.197648",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso11"
@@ -6679,7 +6679,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.010082",
+        "dc:date": "2020-08-17T22:41:50.198025",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso12"
@@ -6690,7 +6690,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.010581",
+        "dc:date": "2020-08-17T22:41:50.198513",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#tso13"
@@ -6701,7 +6701,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.010884",
+        "dc:date": "2020-08-17T22:41:50.198837",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn01"
@@ -6712,7 +6712,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.011514",
+        "dc:date": "2020-08-17T22:41:50.199427",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/expand-manifest#ttn02"
@@ -6723,7 +6723,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.014225",
+        "dc:date": "2020-08-17T22:41:50.201445",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0001"
@@ -6734,7 +6734,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.014895",
+        "dc:date": "2020-08-17T22:41:50.20213",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0002"
@@ -6745,7 +6745,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.015316",
+        "dc:date": "2020-08-17T22:41:50.202614",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0003"
@@ -6756,7 +6756,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.015958",
+        "dc:date": "2020-08-17T22:41:50.203241",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0004"
@@ -6767,7 +6767,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.016608",
+        "dc:date": "2020-08-17T22:41:50.203835",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0005"
@@ -6778,7 +6778,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.017077",
+        "dc:date": "2020-08-17T22:41:50.204344",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0006"
@@ -6789,7 +6789,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.017624",
+        "dc:date": "2020-08-17T22:41:50.204906",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0007"
@@ -6800,7 +6800,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.018292",
+        "dc:date": "2020-08-17T22:41:50.205383",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0008"
@@ -6811,7 +6811,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.018991",
+        "dc:date": "2020-08-17T22:41:50.206057",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0009"
@@ -6822,7 +6822,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.019539",
+        "dc:date": "2020-08-17T22:41:50.206584",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0010"
@@ -6833,7 +6833,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.020127",
+        "dc:date": "2020-08-17T22:41:50.207114",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0011"
@@ -6844,7 +6844,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.020751",
+        "dc:date": "2020-08-17T22:41:50.207701",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0012"
@@ -6855,7 +6855,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.021209",
+        "dc:date": "2020-08-17T22:41:50.20822",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0013"
@@ -6866,7 +6866,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.021807",
+        "dc:date": "2020-08-17T22:41:50.208798",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0015"
@@ -6877,7 +6877,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.022457",
+        "dc:date": "2020-08-17T22:41:50.209465",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0016"
@@ -6888,7 +6888,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.023196",
+        "dc:date": "2020-08-17T22:41:50.210092",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0017"
@@ -6899,7 +6899,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.023836",
+        "dc:date": "2020-08-17T22:41:50.210688",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0018"
@@ -6910,7 +6910,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.024333",
+        "dc:date": "2020-08-17T22:41:50.211502",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0019"
@@ -6921,7 +6921,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.025092",
+        "dc:date": "2020-08-17T22:41:50.212257",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0020"
@@ -6932,7 +6932,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.02592",
+        "dc:date": "2020-08-17T22:41:50.213039",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0021"
@@ -6943,7 +6943,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.026446",
+        "dc:date": "2020-08-17T22:41:50.213943",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0022"
@@ -6954,7 +6954,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.027193",
+        "dc:date": "2020-08-17T22:41:50.215002",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0023"
@@ -6965,7 +6965,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.027816",
+        "dc:date": "2020-08-17T22:41:50.215741",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0024"
@@ -6976,7 +6976,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.028251",
+        "dc:date": "2020-08-17T22:41:50.216385",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0025"
@@ -6987,7 +6987,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.028798",
+        "dc:date": "2020-08-17T22:41:50.216905",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0027"
@@ -6998,7 +6998,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.02931",
+        "dc:date": "2020-08-17T22:41:50.217386",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0028"
@@ -7009,7 +7009,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.029812",
+        "dc:date": "2020-08-17T22:41:50.217854",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0030"
@@ -7020,7 +7020,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.030362",
+        "dc:date": "2020-08-17T22:41:50.218373",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0031"
@@ -7031,7 +7031,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.030789",
+        "dc:date": "2020-08-17T22:41:50.218853",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0032"
@@ -7042,7 +7042,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.031264",
+        "dc:date": "2020-08-17T22:41:50.219336",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0033"
@@ -7053,7 +7053,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.031774",
+        "dc:date": "2020-08-17T22:41:50.219785",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0034"
@@ -7064,7 +7064,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.032316",
+        "dc:date": "2020-08-17T22:41:50.220269",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0035"
@@ -7075,7 +7075,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.033567",
+        "dc:date": "2020-08-17T22:41:50.220996",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0036"
@@ -7086,7 +7086,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.034252",
+        "dc:date": "2020-08-17T22:41:50.22149",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0037"
@@ -7097,7 +7097,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.035784",
+        "dc:date": "2020-08-17T22:41:50.221974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0039"
@@ -7108,7 +7108,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.03635",
+        "dc:date": "2020-08-17T22:41:50.222451",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0040"
@@ -7119,7 +7119,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.036906",
+        "dc:date": "2020-08-17T22:41:50.222888",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0041"
@@ -7130,7 +7130,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.037368",
+        "dc:date": "2020-08-17T22:41:50.223353",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0042"
@@ -7141,7 +7141,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.037888",
+        "dc:date": "2020-08-17T22:41:50.22377",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0043"
@@ -7152,7 +7152,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.038534",
+        "dc:date": "2020-08-17T22:41:50.224358",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0044"
@@ -7163,7 +7163,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.039116",
+        "dc:date": "2020-08-17T22:41:50.224835",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0045"
@@ -7174,7 +7174,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.039601",
+        "dc:date": "2020-08-17T22:41:50.225296",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0046"
@@ -7185,7 +7185,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.040084",
+        "dc:date": "2020-08-17T22:41:50.225732",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0047"
@@ -7196,7 +7196,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.040542",
+        "dc:date": "2020-08-17T22:41:50.226159",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0048"
@@ -7207,7 +7207,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.041006",
+        "dc:date": "2020-08-17T22:41:50.22661",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#t0049"
@@ -7218,7 +7218,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.041452",
+        "dc:date": "2020-08-17T22:41:50.226878",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#te001"
@@ -7229,7 +7229,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.041756",
+        "dc:date": "2020-08-17T22:41:50.227234",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin01"
@@ -7240,7 +7240,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.042128",
+        "dc:date": "2020-08-17T22:41:50.227592",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin02"
@@ -7251,7 +7251,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.042615",
+        "dc:date": "2020-08-17T22:41:50.2281",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin03"
@@ -7262,7 +7262,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.043029",
+        "dc:date": "2020-08-17T22:41:50.228532",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin04"
@@ -7273,7 +7273,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.043507",
+        "dc:date": "2020-08-17T22:41:50.228952",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin05"
@@ -7284,7 +7284,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.044439",
+        "dc:date": "2020-08-17T22:41:50.229771",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tin06"
@@ -7295,7 +7295,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.04489",
+        "dc:date": "2020-08-17T22:41:50.230216",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli01"
@@ -7306,7 +7306,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.045343",
+        "dc:date": "2020-08-17T22:41:50.230634",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli02"
@@ -7317,7 +7317,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.045884",
+        "dc:date": "2020-08-17T22:41:50.231076",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/flatten-manifest#tli03"
@@ -7328,7 +7328,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.046958",
+        "dc:date": "2020-08-17T22:41:50.232628",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0001"
@@ -7339,7 +7339,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.04739",
+        "dc:date": "2020-08-17T22:41:50.232988",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0002"
@@ -7350,7 +7350,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.047744",
+        "dc:date": "2020-08-17T22:41:50.233305",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0003"
@@ -7361,7 +7361,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.048139",
+        "dc:date": "2020-08-17T22:41:50.233675",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0004"
@@ -7372,7 +7372,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.048594",
+        "dc:date": "2020-08-17T22:41:50.234088",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0005"
@@ -7383,7 +7383,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.049065",
+        "dc:date": "2020-08-17T22:41:50.234591",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0006"
@@ -7394,7 +7394,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.049628",
+        "dc:date": "2020-08-17T22:41:50.234982",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0007"
@@ -7405,7 +7405,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.050023",
+        "dc:date": "2020-08-17T22:41:50.235332",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0009"
@@ -7416,7 +7416,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.050339",
+        "dc:date": "2020-08-17T22:41:50.235673",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0010"
@@ -7427,7 +7427,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.050742",
+        "dc:date": "2020-08-17T22:41:50.236052",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0011"
@@ -7438,7 +7438,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.051082",
+        "dc:date": "2020-08-17T22:41:50.236425",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0012"
@@ -7449,7 +7449,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.051485",
+        "dc:date": "2020-08-17T22:41:50.236757",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0013"
@@ -7460,7 +7460,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.051854",
+        "dc:date": "2020-08-17T22:41:50.237168",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0014"
@@ -7471,7 +7471,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.052183",
+        "dc:date": "2020-08-17T22:41:50.237444",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0015"
@@ -7482,7 +7482,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.052553",
+        "dc:date": "2020-08-17T22:41:50.237809",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0016"
@@ -7493,7 +7493,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.052878",
+        "dc:date": "2020-08-17T22:41:50.238211",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0017"
@@ -7504,7 +7504,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.053281",
+        "dc:date": "2020-08-17T22:41:50.238559",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0018"
@@ -7515,7 +7515,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.053638",
+        "dc:date": "2020-08-17T22:41:50.238884",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0019"
@@ -7526,7 +7526,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.054048",
+        "dc:date": "2020-08-17T22:41:50.239246",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0020"
@@ -7537,7 +7537,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.054377",
+        "dc:date": "2020-08-17T22:41:50.239608",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0021"
@@ -7548,7 +7548,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.054738",
+        "dc:date": "2020-08-17T22:41:50.239952",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0022"
@@ -7559,7 +7559,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.055003",
+        "dc:date": "2020-08-17T22:41:50.24022",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0023"
@@ -7570,7 +7570,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.055372",
+        "dc:date": "2020-08-17T22:41:50.240486",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0024"
@@ -7581,7 +7581,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.055715",
+        "dc:date": "2020-08-17T22:41:50.240752",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0025"
@@ -7592,7 +7592,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.056101",
+        "dc:date": "2020-08-17T22:41:50.241039",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#t0026"
@@ -7603,7 +7603,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.056393",
+        "dc:date": "2020-08-17T22:41:50.241354",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi01"
@@ -7614,7 +7614,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.056672",
+        "dc:date": "2020-08-17T22:41:50.241522",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi02"
@@ -7625,7 +7625,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.056878",
+        "dc:date": "2020-08-17T22:41:50.2417",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi03"
@@ -7636,7 +7636,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.057059",
+        "dc:date": "2020-08-17T22:41:50.24188",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi04"
@@ -7647,7 +7647,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.057066",
+        "dc:date": "2020-08-17T22:41:50.241887",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi05"
@@ -7658,7 +7658,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.057074",
+        "dc:date": "2020-08-17T22:41:50.24189",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi06"
@@ -7669,7 +7669,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.0574",
+        "dc:date": "2020-08-17T22:41:50.242202",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi07"
@@ -7680,7 +7680,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.057795",
+        "dc:date": "2020-08-17T22:41:50.242553",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi08"
@@ -7691,7 +7691,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058079",
+        "dc:date": "2020-08-17T22:41:50.242875",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi09"
@@ -7702,7 +7702,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058399",
+        "dc:date": "2020-08-17T22:41:50.243163",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi10"
@@ -7713,7 +7713,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058404",
+        "dc:date": "2020-08-17T22:41:50.24317",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi11"
@@ -7724,7 +7724,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058407",
+        "dc:date": "2020-08-17T22:41:50.243173",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tdi12"
@@ -7735,7 +7735,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058411",
+        "dc:date": "2020-08-17T22:41:50.243182",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs01"
@@ -7746,7 +7746,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058418",
+        "dc:date": "2020-08-17T22:41:50.243187",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs02"
@@ -7757,7 +7757,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058421",
+        "dc:date": "2020-08-17T22:41:50.243192",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs03"
@@ -7768,7 +7768,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058425",
+        "dc:date": "2020-08-17T22:41:50.243195",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs04"
@@ -7779,7 +7779,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058427",
+        "dc:date": "2020-08-17T22:41:50.243198",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs05"
@@ -7790,7 +7790,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058432",
+        "dc:date": "2020-08-17T22:41:50.243202",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs06"
@@ -7801,7 +7801,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058435",
+        "dc:date": "2020-08-17T22:41:50.243205",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs07"
@@ -7812,7 +7812,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058439",
+        "dc:date": "2020-08-17T22:41:50.24321",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs08"
@@ -7823,7 +7823,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058442",
+        "dc:date": "2020-08-17T22:41:50.243214",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs09"
@@ -7834,7 +7834,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058445",
+        "dc:date": "2020-08-17T22:41:50.243218",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs10"
@@ -7845,7 +7845,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058448",
+        "dc:date": "2020-08-17T22:41:50.243221",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tjs11"
@@ -7856,7 +7856,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.058762",
+        "dc:date": "2020-08-17T22:41:50.243619",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli01"
@@ -7867,7 +7867,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.059168",
+        "dc:date": "2020-08-17T22:41:50.243979",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli02"
@@ -7878,7 +7878,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.059309",
+        "dc:date": "2020-08-17T22:41:50.244103",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/fromRdf-manifest#tli03"
@@ -7889,7 +7889,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.061928",
+        "dc:date": "2020-08-17T22:41:50.246059",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0001"
@@ -7900,7 +7900,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.062455",
+        "dc:date": "2020-08-17T22:41:50.246481",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0002"
@@ -7911,7 +7911,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.062932",
+        "dc:date": "2020-08-17T22:41:50.246882",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0003"
@@ -7922,7 +7922,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.063077",
+        "dc:date": "2020-08-17T22:41:50.247",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0004"
@@ -7933,7 +7933,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.063391",
+        "dc:date": "2020-08-17T22:41:50.247262",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0005"
@@ -7944,7 +7944,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.06372",
+        "dc:date": "2020-08-17T22:41:50.247526",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0006"
@@ -7955,7 +7955,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.063996",
+        "dc:date": "2020-08-17T22:41:50.24779",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0007"
@@ -7966,7 +7966,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.064102",
+        "dc:date": "2020-08-17T22:41:50.247888",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0008"
@@ -7977,7 +7977,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.064595",
+        "dc:date": "2020-08-17T22:41:50.248338",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0009"
@@ -7988,7 +7988,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.065585",
+        "dc:date": "2020-08-17T22:41:50.249021",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0010"
@@ -7999,7 +7999,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.067049",
+        "dc:date": "2020-08-17T22:41:50.249659",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0011"
@@ -8010,7 +8010,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.067357",
+        "dc:date": "2020-08-17T22:41:50.249932",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0012"
@@ -8021,7 +8021,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.067366",
+        "dc:date": "2020-08-17T22:41:50.249942",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#t0013"
@@ -8032,8 +8032,8 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.067371",
-        "earl:outcome": "earl:failed"
+        "dc:date": "2020-08-17T22:41:50.252975",
+        "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla01"
     },
@@ -8043,7 +8043,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.069077",
+        "dc:date": "2020-08-17T22:41:50.253457",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla02"
@@ -8054,7 +8054,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.06962",
+        "dc:date": "2020-08-17T22:41:50.253922",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla03"
@@ -8065,7 +8065,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.070093",
+        "dc:date": "2020-08-17T22:41:50.25436",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla04"
@@ -8076,8 +8076,8 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.070102",
-        "earl:outcome": "earl:failed"
+        "dc:date": "2020-08-17T22:41:50.256",
+        "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/remote-doc-manifest#tla05"
     },
@@ -8087,7 +8087,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.074481",
+        "dc:date": "2020-08-17T22:41:50.259904",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0001"
@@ -8098,7 +8098,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.075132",
+        "dc:date": "2020-08-17T22:41:50.260511",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0002"
@@ -8109,7 +8109,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.075669",
+        "dc:date": "2020-08-17T22:41:50.261027",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0003"
@@ -8120,7 +8120,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.076172",
+        "dc:date": "2020-08-17T22:41:50.261561",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0004"
@@ -8131,7 +8131,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.076681",
+        "dc:date": "2020-08-17T22:41:50.262135",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0005"
@@ -8142,7 +8142,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.077678",
+        "dc:date": "2020-08-17T22:41:50.262656",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0006"
@@ -8153,7 +8153,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.078143",
+        "dc:date": "2020-08-17T22:41:50.263222",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0007"
@@ -8164,7 +8164,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.078683",
+        "dc:date": "2020-08-17T22:41:50.263758",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0008"
@@ -8175,7 +8175,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.079207",
+        "dc:date": "2020-08-17T22:41:50.264209",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0009"
@@ -8186,7 +8186,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.079815",
+        "dc:date": "2020-08-17T22:41:50.264819",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0010"
@@ -8197,7 +8197,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.080388",
+        "dc:date": "2020-08-17T22:41:50.26536",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0011"
@@ -8208,7 +8208,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.081004",
+        "dc:date": "2020-08-17T22:41:50.265977",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0012"
@@ -8219,7 +8219,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.082311",
+        "dc:date": "2020-08-17T22:41:50.266487",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0013"
@@ -8230,7 +8230,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.082817",
+        "dc:date": "2020-08-17T22:41:50.267638",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0014"
@@ -8241,7 +8241,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.08344",
+        "dc:date": "2020-08-17T22:41:50.268269",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0015"
@@ -8252,7 +8252,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.083941",
+        "dc:date": "2020-08-17T22:41:50.268739",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0016"
@@ -8263,7 +8263,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.084389",
+        "dc:date": "2020-08-17T22:41:50.269219",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0017"
@@ -8274,7 +8274,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.084827",
+        "dc:date": "2020-08-17T22:41:50.269752",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0018"
@@ -8285,7 +8285,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.085431",
+        "dc:date": "2020-08-17T22:41:50.270264",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0019"
@@ -8296,7 +8296,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.086021",
+        "dc:date": "2020-08-17T22:41:50.270802",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0020"
@@ -8307,7 +8307,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.086485",
+        "dc:date": "2020-08-17T22:41:50.271291",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0022"
@@ -8318,7 +8318,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.086982",
+        "dc:date": "2020-08-17T22:41:50.271848",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0023"
@@ -8329,7 +8329,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.087516",
+        "dc:date": "2020-08-17T22:41:50.272304",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0024"
@@ -8340,7 +8340,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.088107",
+        "dc:date": "2020-08-17T22:41:50.272842",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0025"
@@ -8351,7 +8351,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.088606",
+        "dc:date": "2020-08-17T22:41:50.273366",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0026"
@@ -8362,7 +8362,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.089654",
+        "dc:date": "2020-08-17T22:41:50.274327",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0027"
@@ -8373,7 +8373,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.090582",
+        "dc:date": "2020-08-17T22:41:50.275166",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0028"
@@ -8384,7 +8384,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.091458",
+        "dc:date": "2020-08-17T22:41:50.275996",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0029"
@@ -8395,7 +8395,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.09241",
+        "dc:date": "2020-08-17T22:41:50.276997",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0030"
@@ -8406,7 +8406,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.093139",
+        "dc:date": "2020-08-17T22:41:50.277785",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0031"
@@ -8417,7 +8417,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.093916",
+        "dc:date": "2020-08-17T22:41:50.278514",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0032"
@@ -8428,7 +8428,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.094667",
+        "dc:date": "2020-08-17T22:41:50.279248",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0033"
@@ -8439,7 +8439,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.09597",
+        "dc:date": "2020-08-17T22:41:50.27996",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0034"
@@ -8450,7 +8450,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.096963",
+        "dc:date": "2020-08-17T22:41:50.280658",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0035"
@@ -8461,7 +8461,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.097664",
+        "dc:date": "2020-08-17T22:41:50.281325",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0036"
@@ -8472,7 +8472,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.098445",
+        "dc:date": "2020-08-17T22:41:50.281815",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0113"
@@ -8483,7 +8483,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.098987",
+        "dc:date": "2020-08-17T22:41:50.28233",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0114"
@@ -8494,7 +8494,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.099585",
+        "dc:date": "2020-08-17T22:41:50.282901",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0115"
@@ -8505,7 +8505,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.100101",
+        "dc:date": "2020-08-17T22:41:50.284095",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0116"
@@ -8516,7 +8516,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.100687",
+        "dc:date": "2020-08-17T22:41:50.284803",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0117"
@@ -8527,7 +8527,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.10128",
+        "dc:date": "2020-08-17T22:41:50.285451",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0119"
@@ -8538,7 +8538,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101286",
+        "dc:date": "2020-08-17T22:41:50.285458",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0120"
@@ -8549,7 +8549,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101288",
+        "dc:date": "2020-08-17T22:41:50.285461",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0121"
@@ -8560,7 +8560,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101292",
+        "dc:date": "2020-08-17T22:41:50.285464",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0122"
@@ -8571,7 +8571,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101295",
+        "dc:date": "2020-08-17T22:41:50.285466",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0123"
@@ -8582,7 +8582,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101298",
+        "dc:date": "2020-08-17T22:41:50.28547",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124"
@@ -8593,7 +8593,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101301",
+        "dc:date": "2020-08-17T22:41:50.285472",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125"
@@ -8604,7 +8604,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101305",
+        "dc:date": "2020-08-17T22:41:50.285476",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0126"
@@ -8615,7 +8615,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101308",
+        "dc:date": "2020-08-17T22:41:50.285491",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0127"
@@ -8626,7 +8626,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101311",
+        "dc:date": "2020-08-17T22:41:50.285494",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0128"
@@ -8637,7 +8637,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101314",
+        "dc:date": "2020-08-17T22:41:50.285496",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0129"
@@ -8648,7 +8648,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101317",
+        "dc:date": "2020-08-17T22:41:50.285499",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0130"
@@ -8659,7 +8659,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.10132",
+        "dc:date": "2020-08-17T22:41:50.285505",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0131"
@@ -8670,7 +8670,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101324",
+        "dc:date": "2020-08-17T22:41:50.285508",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0132"
@@ -8681,7 +8681,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.101839",
+        "dc:date": "2020-08-17T22:41:50.286135",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc001"
@@ -8692,7 +8692,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.102418",
+        "dc:date": "2020-08-17T22:41:50.286591",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc002"
@@ -8703,7 +8703,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.10298",
+        "dc:date": "2020-08-17T22:41:50.287058",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc003"
@@ -8714,7 +8714,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.10352",
+        "dc:date": "2020-08-17T22:41:50.287569",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc004"
@@ -8725,7 +8725,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.104213",
+        "dc:date": "2020-08-17T22:41:50.288253",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc005"
@@ -8736,7 +8736,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.104716",
+        "dc:date": "2020-08-17T22:41:50.288753",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc006"
@@ -8747,7 +8747,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.105359",
+        "dc:date": "2020-08-17T22:41:50.289234",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc007"
@@ -8758,7 +8758,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.105796",
+        "dc:date": "2020-08-17T22:41:50.289659",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc008"
@@ -8769,7 +8769,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.106194",
+        "dc:date": "2020-08-17T22:41:50.289993",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc009"
@@ -8780,7 +8780,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.106741",
+        "dc:date": "2020-08-17T22:41:50.290479",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc010"
@@ -8791,7 +8791,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.107223",
+        "dc:date": "2020-08-17T22:41:50.290885",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc011"
@@ -8802,7 +8802,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.107645",
+        "dc:date": "2020-08-17T22:41:50.291287",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc012"
@@ -8813,7 +8813,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.108285",
+        "dc:date": "2020-08-17T22:41:50.291866",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc013"
@@ -8824,7 +8824,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.108681",
+        "dc:date": "2020-08-17T22:41:50.292235",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc014"
@@ -8835,7 +8835,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.109278",
+        "dc:date": "2020-08-17T22:41:50.292819",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc015"
@@ -8846,7 +8846,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.109788",
+        "dc:date": "2020-08-17T22:41:50.293329",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc016"
@@ -8857,7 +8857,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.110322",
+        "dc:date": "2020-08-17T22:41:50.293802",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc017"
@@ -8868,7 +8868,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.110823",
+        "dc:date": "2020-08-17T22:41:50.294199",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc018"
@@ -8879,7 +8879,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.111562",
+        "dc:date": "2020-08-17T22:41:50.294951",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc019"
@@ -8890,7 +8890,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.11209",
+        "dc:date": "2020-08-17T22:41:50.295478",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc020"
@@ -8901,7 +8901,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.113547",
+        "dc:date": "2020-08-17T22:41:50.296264",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc021"
@@ -8912,7 +8912,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.11458",
+        "dc:date": "2020-08-17T22:41:50.296836",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc022"
@@ -8923,7 +8923,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.115203",
+        "dc:date": "2020-08-17T22:41:50.297343",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc023"
@@ -8934,7 +8934,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.115956",
+        "dc:date": "2020-08-17T22:41:50.298049",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc024"
@@ -8945,7 +8945,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.116626",
+        "dc:date": "2020-08-17T22:41:50.299309",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc025"
@@ -8956,7 +8956,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.117212",
+        "dc:date": "2020-08-17T22:41:50.29996",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc026"
@@ -8967,7 +8967,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.117794",
+        "dc:date": "2020-08-17T22:41:50.300608",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc027"
@@ -8978,7 +8978,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.118305",
+        "dc:date": "2020-08-17T22:41:50.301072",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc028"
@@ -8989,7 +8989,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.118534",
+        "dc:date": "2020-08-17T22:41:50.301381",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc029"
@@ -9000,7 +9000,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.118726",
+        "dc:date": "2020-08-17T22:41:50.301572",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc030"
@@ -9011,7 +9011,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.118731",
+        "dc:date": "2020-08-17T22:41:50.301579",
         "earl:outcome": "earl:untested"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc031"
@@ -9022,7 +9022,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.118735",
+        "dc:date": "2020-08-17T22:41:50.301583",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc032"
@@ -9033,7 +9033,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.118739",
+        "dc:date": "2020-08-17T22:41:50.301586",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc033"
@@ -9044,7 +9044,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.119686",
+        "dc:date": "2020-08-17T22:41:50.302538",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc034"
@@ -9055,7 +9055,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.120321",
+        "dc:date": "2020-08-17T22:41:50.303236",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tc035"
@@ -9066,7 +9066,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.120965",
+        "dc:date": "2020-08-17T22:41:50.303886",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi01"
@@ -9077,7 +9077,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.121912",
+        "dc:date": "2020-08-17T22:41:50.304753",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi02"
@@ -9088,7 +9088,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.1226",
+        "dc:date": "2020-08-17T22:41:50.305398",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi03"
@@ -9099,7 +9099,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.123169",
+        "dc:date": "2020-08-17T22:41:50.305864",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi04"
@@ -9110,7 +9110,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.123635",
+        "dc:date": "2020-08-17T22:41:50.306361",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi05"
@@ -9121,7 +9121,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.124084",
+        "dc:date": "2020-08-17T22:41:50.306834",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi06"
@@ -9132,7 +9132,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.12455",
+        "dc:date": "2020-08-17T22:41:50.307296",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi07"
@@ -9143,7 +9143,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.124755",
+        "dc:date": "2020-08-17T22:41:50.307509",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi08"
@@ -9154,7 +9154,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.125081",
+        "dc:date": "2020-08-17T22:41:50.307832",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi09"
@@ -9165,7 +9165,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.125465",
+        "dc:date": "2020-08-17T22:41:50.308178",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi10"
@@ -9176,7 +9176,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.125906",
+        "dc:date": "2020-08-17T22:41:50.308592",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi11"
@@ -9187,7 +9187,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.126386",
+        "dc:date": "2020-08-17T22:41:50.30907",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tdi12"
@@ -9198,7 +9198,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.126645",
+        "dc:date": "2020-08-17T22:41:50.309346",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te001"
@@ -9209,7 +9209,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.12772",
+        "dc:date": "2020-08-17T22:41:50.31017",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te002"
@@ -9220,7 +9220,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.128174",
+        "dc:date": "2020-08-17T22:41:50.31049",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te003"
@@ -9231,7 +9231,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.129333",
+        "dc:date": "2020-08-17T22:41:50.311494",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te004"
@@ -9242,7 +9242,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.130304",
+        "dc:date": "2020-08-17T22:41:50.312457",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te005"
@@ -9253,7 +9253,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.130899",
+        "dc:date": "2020-08-17T22:41:50.313166",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te006"
@@ -9264,7 +9264,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.13144",
+        "dc:date": "2020-08-17T22:41:50.313784",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te007"
@@ -9275,7 +9275,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.131928",
+        "dc:date": "2020-08-17T22:41:50.314336",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te008"
@@ -9286,7 +9286,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.133406",
+        "dc:date": "2020-08-17T22:41:50.315345",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te009"
@@ -9297,7 +9297,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.133954",
+        "dc:date": "2020-08-17T22:41:50.315822",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te010"
@@ -9308,7 +9308,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.134478",
+        "dc:date": "2020-08-17T22:41:50.316347",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te011"
@@ -9319,7 +9319,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.135323",
+        "dc:date": "2020-08-17T22:41:50.317353",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te012"
@@ -9330,7 +9330,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.135893",
+        "dc:date": "2020-08-17T22:41:50.317996",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te013"
@@ -9341,7 +9341,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.136627",
+        "dc:date": "2020-08-17T22:41:50.319211",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te015"
@@ -9352,7 +9352,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.137481",
+        "dc:date": "2020-08-17T22:41:50.320083",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te016"
@@ -9363,7 +9363,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.138449",
+        "dc:date": "2020-08-17T22:41:50.321042",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te017"
@@ -9374,7 +9374,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.139231",
+        "dc:date": "2020-08-17T22:41:50.321845",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te018"
@@ -9385,7 +9385,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.139489",
+        "dc:date": "2020-08-17T22:41:50.322135",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te019"
@@ -9396,7 +9396,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.140565",
+        "dc:date": "2020-08-17T22:41:50.323147",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te020"
@@ -9407,7 +9407,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.141709",
+        "dc:date": "2020-08-17T22:41:50.324369",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te021"
@@ -9418,7 +9418,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.142065",
+        "dc:date": "2020-08-17T22:41:50.324793",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te022"
@@ -9429,7 +9429,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.143131",
+        "dc:date": "2020-08-17T22:41:50.325864",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te023"
@@ -9440,7 +9440,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.143752",
+        "dc:date": "2020-08-17T22:41:50.326479",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te024"
@@ -9451,7 +9451,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.144376",
+        "dc:date": "2020-08-17T22:41:50.327135",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te025"
@@ -9462,7 +9462,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.145147",
+        "dc:date": "2020-08-17T22:41:50.327941",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te027"
@@ -9473,7 +9473,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.14583",
+        "dc:date": "2020-08-17T22:41:50.328667",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te028"
@@ -9484,7 +9484,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.147671",
+        "dc:date": "2020-08-17T22:41:50.331108",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te029"
@@ -9495,7 +9495,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.148337",
+        "dc:date": "2020-08-17T22:41:50.331868",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te030"
@@ -9506,7 +9506,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.149076",
+        "dc:date": "2020-08-17T22:41:50.332663",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te031"
@@ -9517,7 +9517,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.149586",
+        "dc:date": "2020-08-17T22:41:50.333148",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te032"
@@ -9528,7 +9528,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.15022",
+        "dc:date": "2020-08-17T22:41:50.333764",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te033"
@@ -9539,7 +9539,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.150805",
+        "dc:date": "2020-08-17T22:41:50.334413",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te034"
@@ -9550,7 +9550,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.151479",
+        "dc:date": "2020-08-17T22:41:50.335527",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te035"
@@ -9561,7 +9561,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.153704",
+        "dc:date": "2020-08-17T22:41:50.33744",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te036"
@@ -9572,7 +9572,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.154435",
+        "dc:date": "2020-08-17T22:41:50.338297",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te037"
@@ -9583,7 +9583,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.155131",
+        "dc:date": "2020-08-17T22:41:50.338974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te039"
@@ -9594,7 +9594,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.155906",
+        "dc:date": "2020-08-17T22:41:50.339708",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te040"
@@ -9605,7 +9605,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.156516",
+        "dc:date": "2020-08-17T22:41:50.340277",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te041"
@@ -9616,7 +9616,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.157054",
+        "dc:date": "2020-08-17T22:41:50.340767",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te042"
@@ -9627,7 +9627,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.157673",
+        "dc:date": "2020-08-17T22:41:50.341351",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te043"
@@ -9638,7 +9638,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.158174",
+        "dc:date": "2020-08-17T22:41:50.341868",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te044"
@@ -9649,7 +9649,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.158405",
+        "dc:date": "2020-08-17T22:41:50.342074",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te045"
@@ -9660,7 +9660,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.158737",
+        "dc:date": "2020-08-17T22:41:50.3423",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te046"
@@ -9671,7 +9671,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.159152",
+        "dc:date": "2020-08-17T22:41:50.34265",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te047"
@@ -9682,7 +9682,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.159821",
+        "dc:date": "2020-08-17T22:41:50.343239",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te048"
@@ -9693,7 +9693,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.160484",
+        "dc:date": "2020-08-17T22:41:50.343797",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te049"
@@ -9704,7 +9704,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.160939",
+        "dc:date": "2020-08-17T22:41:50.344247",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te050"
@@ -9715,7 +9715,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.161457",
+        "dc:date": "2020-08-17T22:41:50.344753",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te051"
@@ -9726,7 +9726,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.161898",
+        "dc:date": "2020-08-17T22:41:50.345179",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te052"
@@ -9737,7 +9737,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.162203",
+        "dc:date": "2020-08-17T22:41:50.345502",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te053"
@@ -9748,7 +9748,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.162593",
+        "dc:date": "2020-08-17T22:41:50.345966",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te054"
@@ -9759,7 +9759,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.162941",
+        "dc:date": "2020-08-17T22:41:50.346307",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te055"
@@ -9770,7 +9770,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.163571",
+        "dc:date": "2020-08-17T22:41:50.347011",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te056"
@@ -9781,7 +9781,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.163998",
+        "dc:date": "2020-08-17T22:41:50.347445",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te057"
@@ -9792,7 +9792,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.164404",
+        "dc:date": "2020-08-17T22:41:50.347914",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te058"
@@ -9803,7 +9803,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.164975",
+        "dc:date": "2020-08-17T22:41:50.348508",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te059"
@@ -9814,7 +9814,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.16569",
+        "dc:date": "2020-08-17T22:41:50.349196",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te060"
@@ -9825,7 +9825,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.166143",
+        "dc:date": "2020-08-17T22:41:50.349736",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te061"
@@ -9836,7 +9836,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.167981",
+        "dc:date": "2020-08-17T22:41:50.351528",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te062"
@@ -9847,7 +9847,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.169063",
+        "dc:date": "2020-08-17T22:41:50.352231",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te063"
@@ -9858,7 +9858,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.169675",
+        "dc:date": "2020-08-17T22:41:50.352807",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te064"
@@ -9869,7 +9869,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.170252",
+        "dc:date": "2020-08-17T22:41:50.353263",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te065"
@@ -9880,7 +9880,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.170941",
+        "dc:date": "2020-08-17T22:41:50.353929",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te066"
@@ -9891,7 +9891,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.17149",
+        "dc:date": "2020-08-17T22:41:50.354353",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te067"
@@ -9902,7 +9902,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.171794",
+        "dc:date": "2020-08-17T22:41:50.354709",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te068"
@@ -9913,7 +9913,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.172296",
+        "dc:date": "2020-08-17T22:41:50.35519",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te069"
@@ -9924,7 +9924,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.172787",
+        "dc:date": "2020-08-17T22:41:50.355702",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te070"
@@ -9935,7 +9935,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.173161",
+        "dc:date": "2020-08-17T22:41:50.356129",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te072"
@@ -9946,7 +9946,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.173808",
+        "dc:date": "2020-08-17T22:41:50.356953",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te073"
@@ -9957,7 +9957,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.174431",
+        "dc:date": "2020-08-17T22:41:50.357792",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te074"
@@ -9968,7 +9968,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.174826",
+        "dc:date": "2020-08-17T22:41:50.358167",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te075"
@@ -9979,7 +9979,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.175189",
+        "dc:date": "2020-08-17T22:41:50.358611",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te076"
@@ -9990,7 +9990,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.175999",
+        "dc:date": "2020-08-17T22:41:50.359422",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te077"
@@ -10001,7 +10001,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.177033",
+        "dc:date": "2020-08-17T22:41:50.360486",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te078"
@@ -10012,7 +10012,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.177391",
+        "dc:date": "2020-08-17T22:41:50.360856",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te079"
@@ -10023,7 +10023,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.1778",
+        "dc:date": "2020-08-17T22:41:50.361249",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te080"
@@ -10034,7 +10034,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.178206",
+        "dc:date": "2020-08-17T22:41:50.361686",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te081"
@@ -10045,7 +10045,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.178561",
+        "dc:date": "2020-08-17T22:41:50.362068",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te082"
@@ -10056,7 +10056,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.178966",
+        "dc:date": "2020-08-17T22:41:50.362526",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te083"
@@ -10067,7 +10067,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.179418",
+        "dc:date": "2020-08-17T22:41:50.362979",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te084"
@@ -10078,7 +10078,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.17977",
+        "dc:date": "2020-08-17T22:41:50.363454",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te085"
@@ -10089,7 +10089,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.180215",
+        "dc:date": "2020-08-17T22:41:50.363927",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te086"
@@ -10100,7 +10100,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.180629",
+        "dc:date": "2020-08-17T22:41:50.364416",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te087"
@@ -10111,7 +10111,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.181455",
+        "dc:date": "2020-08-17T22:41:50.365217",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te088"
@@ -10122,7 +10122,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.181888",
+        "dc:date": "2020-08-17T22:41:50.365592",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te089"
@@ -10133,7 +10133,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.182287",
+        "dc:date": "2020-08-17T22:41:50.365974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te090"
@@ -10144,7 +10144,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.182652",
+        "dc:date": "2020-08-17T22:41:50.366411",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te091"
@@ -10155,7 +10155,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.183748",
+        "dc:date": "2020-08-17T22:41:50.367471",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te092"
@@ -10166,7 +10166,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.184181",
+        "dc:date": "2020-08-17T22:41:50.367859",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te093"
@@ -10177,7 +10177,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.184618",
+        "dc:date": "2020-08-17T22:41:50.368261",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te094"
@@ -10188,7 +10188,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.185639",
+        "dc:date": "2020-08-17T22:41:50.368719",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te095"
@@ -10199,7 +10199,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.186158",
+        "dc:date": "2020-08-17T22:41:50.369159",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te096"
@@ -10210,7 +10210,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.186596",
+        "dc:date": "2020-08-17T22:41:50.369612",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te097"
@@ -10221,7 +10221,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.187075",
+        "dc:date": "2020-08-17T22:41:50.370101",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te098"
@@ -10232,7 +10232,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.187648",
+        "dc:date": "2020-08-17T22:41:50.37066",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te099"
@@ -10243,7 +10243,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.188208",
+        "dc:date": "2020-08-17T22:41:50.371234",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te100"
@@ -10254,7 +10254,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.188806",
+        "dc:date": "2020-08-17T22:41:50.371732",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te101"
@@ -10265,7 +10265,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.189218",
+        "dc:date": "2020-08-17T22:41:50.37217",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te102"
@@ -10276,7 +10276,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.189693",
+        "dc:date": "2020-08-17T22:41:50.37259",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te103"
@@ -10287,7 +10287,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.190201",
+        "dc:date": "2020-08-17T22:41:50.373001",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te104"
@@ -10298,7 +10298,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.190755",
+        "dc:date": "2020-08-17T22:41:50.373541",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te105"
@@ -10309,7 +10309,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.191316",
+        "dc:date": "2020-08-17T22:41:50.374062",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te106"
@@ -10320,7 +10320,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.191874",
+        "dc:date": "2020-08-17T22:41:50.374572",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te107"
@@ -10331,7 +10331,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.192535",
+        "dc:date": "2020-08-17T22:41:50.375152",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te108"
@@ -10342,7 +10342,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.192938",
+        "dc:date": "2020-08-17T22:41:50.375541",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te109"
@@ -10353,7 +10353,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.193948",
+        "dc:date": "2020-08-17T22:41:50.37646",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te110"
@@ -10364,7 +10364,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.194962",
+        "dc:date": "2020-08-17T22:41:50.377766",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te111"
@@ -10375,7 +10375,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.195924",
+        "dc:date": "2020-08-17T22:41:50.379178",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te112"
@@ -10386,7 +10386,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.196392",
+        "dc:date": "2020-08-17T22:41:50.379676",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te113"
@@ -10397,7 +10397,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.196809",
+        "dc:date": "2020-08-17T22:41:50.380124",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te114"
@@ -10408,7 +10408,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.197174",
+        "dc:date": "2020-08-17T22:41:50.380545",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te117"
@@ -10419,7 +10419,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.197774",
+        "dc:date": "2020-08-17T22:41:50.381251",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te118"
@@ -10430,7 +10430,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.198303",
+        "dc:date": "2020-08-17T22:41:50.381845",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te119"
@@ -10441,7 +10441,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.198978",
+        "dc:date": "2020-08-17T22:41:50.38257",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te120"
@@ -10452,7 +10452,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.199542",
+        "dc:date": "2020-08-17T22:41:50.383199",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te121"
@@ -10463,7 +10463,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.200136",
+        "dc:date": "2020-08-17T22:41:50.38363",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te122"
@@ -10474,7 +10474,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.200143",
+        "dc:date": "2020-08-17T22:41:50.383636",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te123"
@@ -10485,7 +10485,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.20065",
+        "dc:date": "2020-08-17T22:41:50.384139",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0124"
@@ -10496,7 +10496,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.201159",
+        "dc:date": "2020-08-17T22:41:50.384728",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#t0125"
@@ -10507,7 +10507,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.202248",
+        "dc:date": "2020-08-17T22:41:50.385974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te126"
@@ -10518,7 +10518,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.203708",
+        "dc:date": "2020-08-17T22:41:50.387525",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te127"
@@ -10529,7 +10529,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.206089",
+        "dc:date": "2020-08-17T22:41:50.389387",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te128"
@@ -10540,7 +10540,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.206578",
+        "dc:date": "2020-08-17T22:41:50.389892",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te129"
@@ -10551,7 +10551,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.207023",
+        "dc:date": "2020-08-17T22:41:50.390418",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#te130"
@@ -10562,7 +10562,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.207239",
+        "dc:date": "2020-08-17T22:41:50.390741",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec01"
@@ -10573,7 +10573,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.207247",
+        "dc:date": "2020-08-17T22:41:50.390747",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tec02"
@@ -10584,7 +10584,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.207433",
+        "dc:date": "2020-08-17T22:41:50.390998",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tem01"
@@ -10595,7 +10595,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.207651",
+        "dc:date": "2020-08-17T22:41:50.391202",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten01"
@@ -10606,7 +10606,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.207898",
+        "dc:date": "2020-08-17T22:41:50.391421",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten02"
@@ -10617,7 +10617,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.208098",
+        "dc:date": "2020-08-17T22:41:50.391687",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten03"
@@ -10628,7 +10628,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.20829",
+        "dc:date": "2020-08-17T22:41:50.391884",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten04"
@@ -10639,7 +10639,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.208564",
+        "dc:date": "2020-08-17T22:41:50.392089",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten05"
@@ -10650,7 +10650,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.208785",
+        "dc:date": "2020-08-17T22:41:50.392356",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ten06"
@@ -10661,7 +10661,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.208978",
+        "dc:date": "2020-08-17T22:41:50.392553",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep02"
@@ -10672,7 +10672,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.20921",
+        "dc:date": "2020-08-17T22:41:50.392741",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tep03"
@@ -10683,7 +10683,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.209394",
+        "dc:date": "2020-08-17T22:41:50.39295",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter01"
@@ -10694,7 +10694,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.209584",
+        "dc:date": "2020-08-17T22:41:50.393151",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter04"
@@ -10705,7 +10705,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.209896",
+        "dc:date": "2020-08-17T22:41:50.393477",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter05"
@@ -10716,7 +10716,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.210098",
+        "dc:date": "2020-08-17T22:41:50.39371",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter06"
@@ -10727,7 +10727,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.210321",
+        "dc:date": "2020-08-17T22:41:50.393878",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter07"
@@ -10738,7 +10738,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.210532",
+        "dc:date": "2020-08-17T22:41:50.394166",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter08"
@@ -10749,7 +10749,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.210783",
+        "dc:date": "2020-08-17T22:41:50.394459",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter09"
@@ -10760,7 +10760,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.211071",
+        "dc:date": "2020-08-17T22:41:50.394712",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter10"
@@ -10771,7 +10771,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.211331",
+        "dc:date": "2020-08-17T22:41:50.394933",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter11"
@@ -10782,7 +10782,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.21163",
+        "dc:date": "2020-08-17T22:41:50.395231",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter12"
@@ -10793,7 +10793,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.211953",
+        "dc:date": "2020-08-17T22:41:50.395507",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter13"
@@ -10804,7 +10804,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.212205",
+        "dc:date": "2020-08-17T22:41:50.395744",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter14"
@@ -10815,7 +10815,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.212523",
+        "dc:date": "2020-08-17T22:41:50.396033",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter15"
@@ -10826,7 +10826,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.212788",
+        "dc:date": "2020-08-17T22:41:50.396278",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter17"
@@ -10837,7 +10837,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.213042",
+        "dc:date": "2020-08-17T22:41:50.396592",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter18"
@@ -10848,7 +10848,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.213297",
+        "dc:date": "2020-08-17T22:41:50.397469",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter19"
@@ -10859,7 +10859,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.213518",
+        "dc:date": "2020-08-17T22:41:50.397652",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter20"
@@ -10870,7 +10870,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.213751",
+        "dc:date": "2020-08-17T22:41:50.397944",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter21"
@@ -10881,7 +10881,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.213926",
+        "dc:date": "2020-08-17T22:41:50.398213",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter22"
@@ -10892,7 +10892,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.214143",
+        "dc:date": "2020-08-17T22:41:50.398472",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter23"
@@ -10903,7 +10903,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.214342",
+        "dc:date": "2020-08-17T22:41:50.398651",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter25"
@@ -10914,7 +10914,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.214649",
+        "dc:date": "2020-08-17T22:41:50.398974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter26"
@@ -10925,7 +10925,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.214927",
+        "dc:date": "2020-08-17T22:41:50.399272",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter27"
@@ -10936,7 +10936,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.215186",
+        "dc:date": "2020-08-17T22:41:50.399504",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter28"
@@ -10947,7 +10947,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.215454",
+        "dc:date": "2020-08-17T22:41:50.39981",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter29"
@@ -10958,7 +10958,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.215728",
+        "dc:date": "2020-08-17T22:41:50.400044",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter30"
@@ -10969,7 +10969,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.216006",
+        "dc:date": "2020-08-17T22:41:50.400308",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter31"
@@ -10980,7 +10980,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.216233",
+        "dc:date": "2020-08-17T22:41:50.400584",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter33"
@@ -10991,7 +10991,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.216539",
+        "dc:date": "2020-08-17T22:41:50.400853",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter34"
@@ -11002,7 +11002,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.216843",
+        "dc:date": "2020-08-17T22:41:50.401203",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter35"
@@ -11013,7 +11013,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.217123",
+        "dc:date": "2020-08-17T22:41:50.401493",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter36"
@@ -11024,7 +11024,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.217348",
+        "dc:date": "2020-08-17T22:41:50.401811",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter37"
@@ -11035,7 +11035,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.217657",
+        "dc:date": "2020-08-17T22:41:50.402078",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter38"
@@ -11046,7 +11046,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.217857",
+        "dc:date": "2020-08-17T22:41:50.402337",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter39"
@@ -11057,7 +11057,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.218047",
+        "dc:date": "2020-08-17T22:41:50.402513",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter40"
@@ -11068,7 +11068,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.218216",
+        "dc:date": "2020-08-17T22:41:50.402732",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter41"
@@ -11079,7 +11079,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.218429",
+        "dc:date": "2020-08-17T22:41:50.40298",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter42"
@@ -11090,7 +11090,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.218652",
+        "dc:date": "2020-08-17T22:41:50.403193",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter43"
@@ -11101,7 +11101,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.218881",
+        "dc:date": "2020-08-17T22:41:50.403408",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter44"
@@ -11112,7 +11112,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.219093",
+        "dc:date": "2020-08-17T22:41:50.403641",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter48"
@@ -11123,7 +11123,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.219293",
+        "dc:date": "2020-08-17T22:41:50.403865",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter49"
@@ -11134,7 +11134,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.219569",
+        "dc:date": "2020-08-17T22:41:50.404111",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter50"
@@ -11145,7 +11145,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.2198",
+        "dc:date": "2020-08-17T22:41:50.404291",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter51"
@@ -11156,7 +11156,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.219808",
+        "dc:date": "2020-08-17T22:41:50.404297",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter52"
@@ -11167,7 +11167,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.220044",
+        "dc:date": "2020-08-17T22:41:50.40456",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ter53"
@@ -11178,7 +11178,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.220636",
+        "dc:date": "2020-08-17T22:41:50.405062",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin01"
@@ -11189,7 +11189,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.222545",
+        "dc:date": "2020-08-17T22:41:50.405604",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin02"
@@ -11200,7 +11200,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.22316",
+        "dc:date": "2020-08-17T22:41:50.406168",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin03"
@@ -11211,7 +11211,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.223791",
+        "dc:date": "2020-08-17T22:41:50.406707",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin04"
@@ -11222,7 +11222,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.224355",
+        "dc:date": "2020-08-17T22:41:50.407216",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin05"
@@ -11233,7 +11233,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.226103",
+        "dc:date": "2020-08-17T22:41:50.408971",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin06"
@@ -11244,7 +11244,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.226376",
+        "dc:date": "2020-08-17T22:41:50.409248",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin07"
@@ -11255,7 +11255,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.226668",
+        "dc:date": "2020-08-17T22:41:50.409543",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin08"
@@ -11266,7 +11266,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.226948",
+        "dc:date": "2020-08-17T22:41:50.4098",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tin09"
@@ -11277,7 +11277,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.227425",
+        "dc:date": "2020-08-17T22:41:50.410319",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs01"
@@ -11288,7 +11288,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.227961",
+        "dc:date": "2020-08-17T22:41:50.410913",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs02"
@@ -11299,7 +11299,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.228473",
+        "dc:date": "2020-08-17T22:41:50.411521",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs03"
@@ -11310,7 +11310,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.228931",
+        "dc:date": "2020-08-17T22:41:50.412133",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs04"
@@ -11321,7 +11321,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.22947",
+        "dc:date": "2020-08-17T22:41:50.412638",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs05"
@@ -11332,7 +11332,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.229976",
+        "dc:date": "2020-08-17T22:41:50.413232",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs06"
@@ -11343,7 +11343,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.230459",
+        "dc:date": "2020-08-17T22:41:50.413782",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs07"
@@ -11354,7 +11354,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.230897",
+        "dc:date": "2020-08-17T22:41:50.414346",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs08"
@@ -11365,7 +11365,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.231355",
+        "dc:date": "2020-08-17T22:41:50.414789",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs09"
@@ -11376,7 +11376,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.231925",
+        "dc:date": "2020-08-17T22:41:50.415365",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs10"
@@ -11387,7 +11387,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.232454",
+        "dc:date": "2020-08-17T22:41:50.415917",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs11"
@@ -11398,7 +11398,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.233014",
+        "dc:date": "2020-08-17T22:41:50.416422",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs12"
@@ -11409,7 +11409,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.23354",
+        "dc:date": "2020-08-17T22:41:50.416991",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs13"
@@ -11420,7 +11420,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.234083",
+        "dc:date": "2020-08-17T22:41:50.417538",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs14"
@@ -11431,7 +11431,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.234909",
+        "dc:date": "2020-08-17T22:41:50.417895",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs15"
@@ -11442,7 +11442,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.235383",
+        "dc:date": "2020-08-17T22:41:50.41825",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs16"
@@ -11453,7 +11453,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.235808",
+        "dc:date": "2020-08-17T22:41:50.419265",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs17"
@@ -11464,7 +11464,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.236167",
+        "dc:date": "2020-08-17T22:41:50.419657",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs18"
@@ -11475,7 +11475,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.236568",
+        "dc:date": "2020-08-17T22:41:50.420104",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs19"
@@ -11486,7 +11486,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.236988",
+        "dc:date": "2020-08-17T22:41:50.420506",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs20"
@@ -11497,7 +11497,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.237325",
+        "dc:date": "2020-08-17T22:41:50.420824",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs21"
@@ -11508,7 +11508,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.237729",
+        "dc:date": "2020-08-17T22:41:50.421245",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs22"
@@ -11519,7 +11519,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.238347",
+        "dc:date": "2020-08-17T22:41:50.421669",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tjs23"
@@ -11530,7 +11530,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.238973",
+        "dc:date": "2020-08-17T22:41:50.42225",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli01"
@@ -11541,7 +11541,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.239491",
+        "dc:date": "2020-08-17T22:41:50.42281",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli02"
@@ -11552,7 +11552,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.240039",
+        "dc:date": "2020-08-17T22:41:50.423318",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli03"
@@ -11563,7 +11563,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.240487",
+        "dc:date": "2020-08-17T22:41:50.42368",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli04"
@@ -11574,7 +11574,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.241016",
+        "dc:date": "2020-08-17T22:41:50.42419",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli05"
@@ -11585,7 +11585,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.241444",
+        "dc:date": "2020-08-17T22:41:50.424648",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli06"
@@ -11596,7 +11596,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.241963",
+        "dc:date": "2020-08-17T22:41:50.425084",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli07"
@@ -11607,7 +11607,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.242376",
+        "dc:date": "2020-08-17T22:41:50.425647",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli08"
@@ -11618,7 +11618,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.242937",
+        "dc:date": "2020-08-17T22:41:50.426315",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli09"
@@ -11629,7 +11629,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.243436",
+        "dc:date": "2020-08-17T22:41:50.426913",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tli10"
@@ -11640,7 +11640,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.243931",
+        "dc:date": "2020-08-17T22:41:50.427473",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm001"
@@ -11651,7 +11651,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.244494",
+        "dc:date": "2020-08-17T22:41:50.428008",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm002"
@@ -11662,7 +11662,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.244921",
+        "dc:date": "2020-08-17T22:41:50.428578",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm003"
@@ -11673,7 +11673,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.245437",
+        "dc:date": "2020-08-17T22:41:50.429175",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm004"
@@ -11684,7 +11684,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.245889",
+        "dc:date": "2020-08-17T22:41:50.429578",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm005"
@@ -11695,7 +11695,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.246254",
+        "dc:date": "2020-08-17T22:41:50.430035",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm006"
@@ -11706,7 +11706,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.246697",
+        "dc:date": "2020-08-17T22:41:50.430473",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm007"
@@ -11717,7 +11717,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.247139",
+        "dc:date": "2020-08-17T22:41:50.430949",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm008"
@@ -11728,7 +11728,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.247735",
+        "dc:date": "2020-08-17T22:41:50.431596",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm009"
@@ -11739,7 +11739,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.248315",
+        "dc:date": "2020-08-17T22:41:50.432155",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm010"
@@ -11750,7 +11750,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.248695",
+        "dc:date": "2020-08-17T22:41:50.432664",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm011"
@@ -11761,7 +11761,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.24919",
+        "dc:date": "2020-08-17T22:41:50.433185",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm012"
@@ -11772,7 +11772,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.249615",
+        "dc:date": "2020-08-17T22:41:50.43362",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm013"
@@ -11783,7 +11783,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.249975",
+        "dc:date": "2020-08-17T22:41:50.434081",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm014"
@@ -11794,7 +11794,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.250369",
+        "dc:date": "2020-08-17T22:41:50.434441",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm015"
@@ -11805,7 +11805,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.250752",
+        "dc:date": "2020-08-17T22:41:50.434873",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm016"
@@ -11816,7 +11816,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.251135",
+        "dc:date": "2020-08-17T22:41:50.435304",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm017"
@@ -11827,7 +11827,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.251611",
+        "dc:date": "2020-08-17T22:41:50.435739",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm018"
@@ -11838,7 +11838,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.252011",
+        "dc:date": "2020-08-17T22:41:50.436261",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm019"
@@ -11849,7 +11849,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.252232",
+        "dc:date": "2020-08-17T22:41:50.436476",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tm020"
@@ -11860,7 +11860,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.252615",
+        "dc:date": "2020-08-17T22:41:50.436857",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn001"
@@ -11871,7 +11871,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.253047",
+        "dc:date": "2020-08-17T22:41:50.437326",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn002"
@@ -11882,7 +11882,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.25349",
+        "dc:date": "2020-08-17T22:41:50.437764",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn003"
@@ -11893,7 +11893,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.253897",
+        "dc:date": "2020-08-17T22:41:50.43827",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn004"
@@ -11904,7 +11904,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.254359",
+        "dc:date": "2020-08-17T22:41:50.438667",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn005"
@@ -11915,7 +11915,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.254857",
+        "dc:date": "2020-08-17T22:41:50.439114",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn006"
@@ -11926,7 +11926,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.255418",
+        "dc:date": "2020-08-17T22:41:50.439634",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn007"
@@ -11937,7 +11937,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.256094",
+        "dc:date": "2020-08-17T22:41:50.440183",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tn008"
@@ -11948,7 +11948,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.256759",
+        "dc:date": "2020-08-17T22:41:50.440554",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt01"
@@ -11959,7 +11959,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.257132",
+        "dc:date": "2020-08-17T22:41:50.441015",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt02"
@@ -11970,7 +11970,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.257474",
+        "dc:date": "2020-08-17T22:41:50.441383",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt03"
@@ -11981,7 +11981,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.257815",
+        "dc:date": "2020-08-17T22:41:50.441689",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt04"
@@ -11992,7 +11992,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.258102",
+        "dc:date": "2020-08-17T22:41:50.442004",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt05"
@@ -12003,7 +12003,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.258422",
+        "dc:date": "2020-08-17T22:41:50.442938",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt06"
@@ -12014,7 +12014,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.258789",
+        "dc:date": "2020-08-17T22:41:50.44327",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt07"
@@ -12025,7 +12025,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.259152",
+        "dc:date": "2020-08-17T22:41:50.443602",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt08"
@@ -12036,7 +12036,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.259505",
+        "dc:date": "2020-08-17T22:41:50.44392",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt09"
@@ -12047,7 +12047,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.259861",
+        "dc:date": "2020-08-17T22:41:50.444297",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt10"
@@ -12058,7 +12058,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.260193",
+        "dc:date": "2020-08-17T22:41:50.444621",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt11"
@@ -12069,7 +12069,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.260552",
+        "dc:date": "2020-08-17T22:41:50.444967",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt12"
@@ -12080,7 +12080,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.260887",
+        "dc:date": "2020-08-17T22:41:50.445296",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt13"
@@ -12091,7 +12091,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.261253",
+        "dc:date": "2020-08-17T22:41:50.445647",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt14"
@@ -12102,7 +12102,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.261605",
+        "dc:date": "2020-08-17T22:41:50.445964",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt15"
@@ -12113,7 +12113,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.261988",
+        "dc:date": "2020-08-17T22:41:50.446352",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tnt16"
@@ -12124,7 +12124,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.262501",
+        "dc:date": "2020-08-17T22:41:50.446839",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp001"
@@ -12135,7 +12135,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.26304",
+        "dc:date": "2020-08-17T22:41:50.447364",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp002"
@@ -12146,7 +12146,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.263612",
+        "dc:date": "2020-08-17T22:41:50.448009",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp003"
@@ -12157,7 +12157,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.264026",
+        "dc:date": "2020-08-17T22:41:50.448464",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tp004"
@@ -12168,7 +12168,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.264223",
+        "dc:date": "2020-08-17T22:41:50.448657",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi01"
@@ -12179,7 +12179,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.264395",
+        "dc:date": "2020-08-17T22:41:50.448906",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi02"
@@ -12190,7 +12190,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.26459",
+        "dc:date": "2020-08-17T22:41:50.449172",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi03"
@@ -12201,7 +12201,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.264775",
+        "dc:date": "2020-08-17T22:41:50.449436",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi04"
@@ -12212,7 +12212,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.264986",
+        "dc:date": "2020-08-17T22:41:50.449671",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi05"
@@ -12223,7 +12223,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.265789",
+        "dc:date": "2020-08-17T22:41:50.450324",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi06"
@@ -12234,7 +12234,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.26654",
+        "dc:date": "2020-08-17T22:41:50.451123",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi07"
@@ -12245,7 +12245,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.267209",
+        "dc:date": "2020-08-17T22:41:50.451827",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi08"
@@ -12256,7 +12256,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.26803",
+        "dc:date": "2020-08-17T22:41:50.452589",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi09"
@@ -12267,7 +12267,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.268675",
+        "dc:date": "2020-08-17T22:41:50.453249",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi10"
@@ -12278,7 +12278,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.269072",
+        "dc:date": "2020-08-17T22:41:50.453688",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpi11"
@@ -12289,7 +12289,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.269331",
+        "dc:date": "2020-08-17T22:41:50.453997",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr01"
@@ -12300,7 +12300,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.269909",
+        "dc:date": "2020-08-17T22:41:50.454607",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr02"
@@ -12311,7 +12311,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.270195",
+        "dc:date": "2020-08-17T22:41:50.454905",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr03"
@@ -12322,7 +12322,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.270499",
+        "dc:date": "2020-08-17T22:41:50.455196",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr04"
@@ -12333,7 +12333,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.270726",
+        "dc:date": "2020-08-17T22:41:50.455426",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr05"
@@ -12344,7 +12344,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.271157",
+        "dc:date": "2020-08-17T22:41:50.455729",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr06"
@@ -12355,7 +12355,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.271623",
+        "dc:date": "2020-08-17T22:41:50.456139",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr08"
@@ -12366,7 +12366,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.271894",
+        "dc:date": "2020-08-17T22:41:50.456398",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr09"
@@ -12377,7 +12377,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.272325",
+        "dc:date": "2020-08-17T22:41:50.456832",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr10"
@@ -12388,7 +12388,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.272619",
+        "dc:date": "2020-08-17T22:41:50.457082",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr11"
@@ -12399,7 +12399,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.272878",
+        "dc:date": "2020-08-17T22:41:50.457383",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr12"
@@ -12410,7 +12410,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.273315",
+        "dc:date": "2020-08-17T22:41:50.457907",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr13"
@@ -12421,7 +12421,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.273756",
+        "dc:date": "2020-08-17T22:41:50.45833",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr14"
@@ -12432,7 +12432,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.274117",
+        "dc:date": "2020-08-17T22:41:50.458847",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr15"
@@ -12443,7 +12443,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.27461",
+        "dc:date": "2020-08-17T22:41:50.459444",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr16"
@@ -12454,7 +12454,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.274884",
+        "dc:date": "2020-08-17T22:41:50.459778",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr17"
@@ -12465,7 +12465,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.275139",
+        "dc:date": "2020-08-17T22:41:50.459972",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr18"
@@ -12476,7 +12476,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.275764",
+        "dc:date": "2020-08-17T22:41:50.460455",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr19"
@@ -12487,7 +12487,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.275997",
+        "dc:date": "2020-08-17T22:41:50.460731",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr20"
@@ -12498,7 +12498,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.276256",
+        "dc:date": "2020-08-17T22:41:50.461021",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr21"
@@ -12509,7 +12509,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.276727",
+        "dc:date": "2020-08-17T22:41:50.461558",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr22"
@@ -12520,7 +12520,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.277118",
+        "dc:date": "2020-08-17T22:41:50.461975",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr23"
@@ -12531,7 +12531,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.277515",
+        "dc:date": "2020-08-17T22:41:50.462408",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr24"
@@ -12542,7 +12542,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.279028",
+        "dc:date": "2020-08-17T22:41:50.463281",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr25"
@@ -12553,7 +12553,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.279425",
+        "dc:date": "2020-08-17T22:41:50.463656",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr26"
@@ -12564,7 +12564,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.279859",
+        "dc:date": "2020-08-17T22:41:50.46469",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr27"
@@ -12575,7 +12575,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.279867",
+        "dc:date": "2020-08-17T22:41:50.464698",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr28"
@@ -12586,7 +12586,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.280278",
+        "dc:date": "2020-08-17T22:41:50.465137",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr29"
@@ -12597,7 +12597,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.280767",
+        "dc:date": "2020-08-17T22:41:50.465671",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr30"
@@ -12608,7 +12608,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.281041",
+        "dc:date": "2020-08-17T22:41:50.465974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr31"
@@ -12619,7 +12619,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.281304",
+        "dc:date": "2020-08-17T22:41:50.46619",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr32"
@@ -12630,7 +12630,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.281498",
+        "dc:date": "2020-08-17T22:41:50.466412",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr33"
@@ -12641,7 +12641,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.282131",
+        "dc:date": "2020-08-17T22:41:50.466927",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr34"
@@ -12652,7 +12652,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.282712",
+        "dc:date": "2020-08-17T22:41:50.467495",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr35"
@@ -12663,7 +12663,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.283334",
+        "dc:date": "2020-08-17T22:41:50.467982",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr36"
@@ -12674,7 +12674,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.284076",
+        "dc:date": "2020-08-17T22:41:50.468515",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr37"
@@ -12685,7 +12685,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.284083",
+        "dc:date": "2020-08-17T22:41:50.468523",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr38"
@@ -12696,7 +12696,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.284086",
+        "dc:date": "2020-08-17T22:41:50.468526",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr39"
@@ -12707,7 +12707,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.284864",
+        "dc:date": "2020-08-17T22:41:50.469027",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tpr40"
@@ -12718,7 +12718,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.285527",
+        "dc:date": "2020-08-17T22:41:50.469657",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#trt01"
@@ -12729,7 +12729,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.285803",
+        "dc:date": "2020-08-17T22:41:50.46997",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso01"
@@ -12740,7 +12740,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.286076",
+        "dc:date": "2020-08-17T22:41:50.470233",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso02"
@@ -12751,7 +12751,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.286516",
+        "dc:date": "2020-08-17T22:41:50.470615",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso03"
@@ -12762,7 +12762,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.287253",
+        "dc:date": "2020-08-17T22:41:50.471478",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso05"
@@ -12773,7 +12773,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.288032",
+        "dc:date": "2020-08-17T22:41:50.472467",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso06"
@@ -12784,7 +12784,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.288618",
+        "dc:date": "2020-08-17T22:41:50.47305",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso07"
@@ -12795,7 +12795,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.289319",
+        "dc:date": "2020-08-17T22:41:50.47379",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso08"
@@ -12806,7 +12806,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.289924",
+        "dc:date": "2020-08-17T22:41:50.474581",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso09"
@@ -12817,7 +12817,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.290362",
+        "dc:date": "2020-08-17T22:41:50.475137",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso10"
@@ -12828,7 +12828,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29091",
+        "dc:date": "2020-08-17T22:41:50.475732",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso11"
@@ -12839,7 +12839,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.291266",
+        "dc:date": "2020-08-17T22:41:50.47603",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso12"
@@ -12850,7 +12850,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.291675",
+        "dc:date": "2020-08-17T22:41:50.47649",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#tso13"
@@ -12861,7 +12861,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29195",
+        "dc:date": "2020-08-17T22:41:50.476725",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn01"
@@ -12872,7 +12872,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.292659",
+        "dc:date": "2020-08-17T22:41:50.477412",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#ttn02"
@@ -12883,7 +12883,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.292993",
+        "dc:date": "2020-08-17T22:41:50.477786",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf01"
@@ -12894,7 +12894,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.293299",
+        "dc:date": "2020-08-17T22:41:50.478219",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf02"
@@ -12905,7 +12905,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.293745",
+        "dc:date": "2020-08-17T22:41:50.478699",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf03"
@@ -12916,7 +12916,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.294218",
+        "dc:date": "2020-08-17T22:41:50.479214",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf04"
@@ -12927,7 +12927,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.294574",
+        "dc:date": "2020-08-17T22:41:50.479578",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf05"
@@ -12938,7 +12938,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.294966",
+        "dc:date": "2020-08-17T22:41:50.479947",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/toRdf-manifest#twf07"
@@ -12949,7 +12949,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295589",
+        "dc:date": "2020-08-17T22:41:50.480583",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te001"
@@ -12960,7 +12960,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295593",
+        "dc:date": "2020-08-17T22:41:50.480586",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tex01"
@@ -12971,7 +12971,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295596",
+        "dc:date": "2020-08-17T22:41:50.480589",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te002"
@@ -12982,7 +12982,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295599",
+        "dc:date": "2020-08-17T22:41:50.480592",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te003"
@@ -12993,7 +12993,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295601",
+        "dc:date": "2020-08-17T22:41:50.480595",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te004"
@@ -13004,7 +13004,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295605",
+        "dc:date": "2020-08-17T22:41:50.48062",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te005"
@@ -13015,7 +13015,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295608",
+        "dc:date": "2020-08-17T22:41:50.480641",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te006"
@@ -13026,7 +13026,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29561",
+        "dc:date": "2020-08-17T22:41:50.480644",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te007"
@@ -13037,7 +13037,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295614",
+        "dc:date": "2020-08-17T22:41:50.480647",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te010"
@@ -13048,7 +13048,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295616",
+        "dc:date": "2020-08-17T22:41:50.48065",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te011"
@@ -13059,7 +13059,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29562",
+        "dc:date": "2020-08-17T22:41:50.480652",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te012"
@@ -13070,7 +13070,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295623",
+        "dc:date": "2020-08-17T22:41:50.480655",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te013"
@@ -13081,7 +13081,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295626",
+        "dc:date": "2020-08-17T22:41:50.480658",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te014"
@@ -13092,7 +13092,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295628",
+        "dc:date": "2020-08-17T22:41:50.480661",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te015"
@@ -13103,7 +13103,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295632",
+        "dc:date": "2020-08-17T22:41:50.480663",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te016"
@@ -13114,7 +13114,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295634",
+        "dc:date": "2020-08-17T22:41:50.480666",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te017"
@@ -13125,7 +13125,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295637",
+        "dc:date": "2020-08-17T22:41:50.480669",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te018"
@@ -13136,7 +13136,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29564",
+        "dc:date": "2020-08-17T22:41:50.480671",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te019"
@@ -13147,7 +13147,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295643",
+        "dc:date": "2020-08-17T22:41:50.480674",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te020"
@@ -13158,7 +13158,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295646",
+        "dc:date": "2020-08-17T22:41:50.480677",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te021"
@@ -13169,7 +13169,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295648",
+        "dc:date": "2020-08-17T22:41:50.48068",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#te022"
@@ -13180,7 +13180,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295651",
+        "dc:date": "2020-08-17T22:41:50.480682",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tc001"
@@ -13191,7 +13191,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295654",
+        "dc:date": "2020-08-17T22:41:50.480685",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tc002"
@@ -13202,7 +13202,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295657",
+        "dc:date": "2020-08-17T22:41:50.480729",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tc003"
@@ -13213,7 +13213,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29566",
+        "dc:date": "2020-08-17T22:41:50.480733",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tc004"
@@ -13224,7 +13224,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295662",
+        "dc:date": "2020-08-17T22:41:50.480736",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tf001"
@@ -13235,7 +13235,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295665",
+        "dc:date": "2020-08-17T22:41:50.480738",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tf002"
@@ -13246,7 +13246,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295668",
+        "dc:date": "2020-08-17T22:41:50.480741",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tf003"
@@ -13257,7 +13257,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295671",
+        "dc:date": "2020-08-17T22:41:50.480744",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tf004"
@@ -13268,7 +13268,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295674",
+        "dc:date": "2020-08-17T22:41:50.480747",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr001"
@@ -13279,7 +13279,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295677",
+        "dc:date": "2020-08-17T22:41:50.480749",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr002"
@@ -13290,7 +13290,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29568",
+        "dc:date": "2020-08-17T22:41:50.480752",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr003"
@@ -13301,7 +13301,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295683",
+        "dc:date": "2020-08-17T22:41:50.480755",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr004"
@@ -13312,7 +13312,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295685",
+        "dc:date": "2020-08-17T22:41:50.480757",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr005"
@@ -13323,7 +13323,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295688",
+        "dc:date": "2020-08-17T22:41:50.48076",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr006"
@@ -13334,7 +13334,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295717",
+        "dc:date": "2020-08-17T22:41:50.480763",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr007"
@@ -13345,7 +13345,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29572",
+        "dc:date": "2020-08-17T22:41:50.480765",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr010"
@@ -13356,7 +13356,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295723",
+        "dc:date": "2020-08-17T22:41:50.480769",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr011"
@@ -13367,7 +13367,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295726",
+        "dc:date": "2020-08-17T22:41:50.480772",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr012"
@@ -13378,7 +13378,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295729",
+        "dc:date": "2020-08-17T22:41:50.480775",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr013"
@@ -13389,7 +13389,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295732",
+        "dc:date": "2020-08-17T22:41:50.480778",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr014"
@@ -13400,7 +13400,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295735",
+        "dc:date": "2020-08-17T22:41:50.480794",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr015"
@@ -13411,7 +13411,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295739",
+        "dc:date": "2020-08-17T22:41:50.480797",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr016"
@@ -13422,7 +13422,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295742",
+        "dc:date": "2020-08-17T22:41:50.480803",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr017"
@@ -13433,7 +13433,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295745",
+        "dc:date": "2020-08-17T22:41:50.480806",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr018"
@@ -13444,7 +13444,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295749",
+        "dc:date": "2020-08-17T22:41:50.480808",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr019"
@@ -13455,7 +13455,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29576",
+        "dc:date": "2020-08-17T22:41:50.480811",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr020"
@@ -13466,7 +13466,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.295767",
+        "dc:date": "2020-08-17T22:41:50.480814",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr021"
@@ -13477,7 +13477,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.29577",
+        "dc:date": "2020-08-17T22:41:50.480817",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-api/tests/html-manifest#tr022"
@@ -13488,7 +13488,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.299358",
+        "dc:date": "2020-08-17T22:41:50.484382",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0001"
@@ -13499,7 +13499,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.300826",
+        "dc:date": "2020-08-17T22:41:50.485305",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0002"
@@ -13510,7 +13510,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.301733",
+        "dc:date": "2020-08-17T22:41:50.486117",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0003"
@@ -13521,7 +13521,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.302954",
+        "dc:date": "2020-08-17T22:41:50.486947",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0004"
@@ -13532,7 +13532,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.303925",
+        "dc:date": "2020-08-17T22:41:50.487661",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0005"
@@ -13543,7 +13543,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.304845",
+        "dc:date": "2020-08-17T22:41:50.488412",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0006"
@@ -13554,7 +13554,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.305831",
+        "dc:date": "2020-08-17T22:41:50.489078",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0007"
@@ -13565,7 +13565,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.306941",
+        "dc:date": "2020-08-17T22:41:50.490028",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0008"
@@ -13576,7 +13576,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.3079",
+        "dc:date": "2020-08-17T22:41:50.49089",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0009"
@@ -13587,7 +13587,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.30791",
+        "dc:date": "2020-08-17T22:41:50.490913",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0011"
@@ -13598,7 +13598,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.308853",
+        "dc:date": "2020-08-17T22:41:50.491832",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0012"
@@ -13609,7 +13609,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.309556",
+        "dc:date": "2020-08-17T22:41:50.492598",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0013"
@@ -13620,7 +13620,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.310329",
+        "dc:date": "2020-08-17T22:41:50.493426",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0014"
@@ -13631,7 +13631,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.314296",
+        "dc:date": "2020-08-17T22:41:50.497304",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0015"
@@ -13642,7 +13642,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.316132",
+        "dc:date": "2020-08-17T22:41:50.49826",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0016"
@@ -13653,7 +13653,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.317556",
+        "dc:date": "2020-08-17T22:41:50.499215",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0017"
@@ -13664,7 +13664,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.318562",
+        "dc:date": "2020-08-17T22:41:50.499975",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0018"
@@ -13675,7 +13675,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.319581",
+        "dc:date": "2020-08-17T22:41:50.500768",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0019"
@@ -13686,7 +13686,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.320908",
+        "dc:date": "2020-08-17T22:41:50.501919",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0020"
@@ -13697,7 +13697,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.322117",
+        "dc:date": "2020-08-17T22:41:50.503001",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0021"
@@ -13708,7 +13708,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.322944",
+        "dc:date": "2020-08-17T22:41:50.503693",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0022"
@@ -13719,7 +13719,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.322952",
+        "dc:date": "2020-08-17T22:41:50.503701",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0023"
@@ -13730,7 +13730,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.32375",
+        "dc:date": "2020-08-17T22:41:50.504407",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0024"
@@ -13741,7 +13741,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324548",
+        "dc:date": "2020-08-17T22:41:50.505204",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0025"
@@ -13752,7 +13752,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324556",
+        "dc:date": "2020-08-17T22:41:50.505211",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0026"
@@ -13763,7 +13763,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324559",
+        "dc:date": "2020-08-17T22:41:50.505215",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0027"
@@ -13774,7 +13774,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324575",
+        "dc:date": "2020-08-17T22:41:50.505217",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0028"
@@ -13785,7 +13785,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324578",
+        "dc:date": "2020-08-17T22:41:50.50522",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0029"
@@ -13796,7 +13796,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324581",
+        "dc:date": "2020-08-17T22:41:50.505223",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0030"
@@ -13807,7 +13807,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324584",
+        "dc:date": "2020-08-17T22:41:50.505226",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0031"
@@ -13818,7 +13818,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.324587",
+        "dc:date": "2020-08-17T22:41:50.505229",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0032"
@@ -13829,7 +13829,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325367",
+        "dc:date": "2020-08-17T22:41:50.505956",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0033"
@@ -13840,7 +13840,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325374",
+        "dc:date": "2020-08-17T22:41:50.505963",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0034"
@@ -13851,7 +13851,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325377",
+        "dc:date": "2020-08-17T22:41:50.505966",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0035"
@@ -13862,7 +13862,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325385",
+        "dc:date": "2020-08-17T22:41:50.505973",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0036"
@@ -13873,7 +13873,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325388",
+        "dc:date": "2020-08-17T22:41:50.505976",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0037"
@@ -13884,7 +13884,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325392",
+        "dc:date": "2020-08-17T22:41:50.505979",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0038"
@@ -13895,7 +13895,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325394",
+        "dc:date": "2020-08-17T22:41:50.505982",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0039"
@@ -13906,7 +13906,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325398",
+        "dc:date": "2020-08-17T22:41:50.505993",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0040"
@@ -13917,7 +13917,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325401",
+        "dc:date": "2020-08-17T22:41:50.505996",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0041"
@@ -13928,7 +13928,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325405",
+        "dc:date": "2020-08-17T22:41:50.506",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0042"
@@ -13939,7 +13939,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325409",
+        "dc:date": "2020-08-17T22:41:50.506004",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0043"
@@ -13950,7 +13950,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325412",
+        "dc:date": "2020-08-17T22:41:50.50601",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0044"
@@ -13961,7 +13961,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.325416",
+        "dc:date": "2020-08-17T22:41:50.506013",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0045"
@@ -13972,7 +13972,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.326071",
+        "dc:date": "2020-08-17T22:41:50.506673",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0046"
@@ -13983,7 +13983,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.326077",
+        "dc:date": "2020-08-17T22:41:50.506693",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0047"
@@ -13994,7 +13994,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.32608",
+        "dc:date": "2020-08-17T22:41:50.506697",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0048"
@@ -14005,7 +14005,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.326829",
+        "dc:date": "2020-08-17T22:41:50.507471",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0049"
@@ -14016,7 +14016,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.326836",
+        "dc:date": "2020-08-17T22:41:50.507479",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0050"
@@ -14027,7 +14027,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.326839",
+        "dc:date": "2020-08-17T22:41:50.507482",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0051"
@@ -14038,7 +14038,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.327337",
+        "dc:date": "2020-08-17T22:41:50.508251",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0052"
@@ -14049,7 +14049,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.327858",
+        "dc:date": "2020-08-17T22:41:50.508983",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0053"
@@ -14060,7 +14060,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.328347",
+        "dc:date": "2020-08-17T22:41:50.50951",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0054"
@@ -14071,7 +14071,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.328354",
+        "dc:date": "2020-08-17T22:41:50.509518",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0055"
@@ -14082,7 +14082,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.329739",
+        "dc:date": "2020-08-17T22:41:50.510507",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0056"
@@ -14093,7 +14093,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.33083",
+        "dc:date": "2020-08-17T22:41:50.511601",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0057"
@@ -14104,7 +14104,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.330837",
+        "dc:date": "2020-08-17T22:41:50.511609",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0058"
@@ -14115,7 +14115,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331564",
+        "dc:date": "2020-08-17T22:41:50.512452",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0059"
@@ -14126,7 +14126,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331571",
+        "dc:date": "2020-08-17T22:41:50.51246",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0060"
@@ -14137,7 +14137,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331575",
+        "dc:date": "2020-08-17T22:41:50.512463",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0061"
@@ -14148,7 +14148,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331583",
+        "dc:date": "2020-08-17T22:41:50.512466",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0062"
@@ -14159,7 +14159,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331587",
+        "dc:date": "2020-08-17T22:41:50.512469",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0063"
@@ -14170,7 +14170,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.33164",
+        "dc:date": "2020-08-17T22:41:50.51251",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0064"
@@ -14181,7 +14181,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331644",
+        "dc:date": "2020-08-17T22:41:50.512513",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0065"
@@ -14192,7 +14192,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331647",
+        "dc:date": "2020-08-17T22:41:50.512517",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0066"
@@ -14203,7 +14203,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.33165",
+        "dc:date": "2020-08-17T22:41:50.512519",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0067"
@@ -14214,7 +14214,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331653",
+        "dc:date": "2020-08-17T22:41:50.512522",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#t0068"
@@ -14225,7 +14225,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.331657",
+        "dc:date": "2020-08-17T22:41:50.512526",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#teo01"
@@ -14236,7 +14236,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.332512",
+        "dc:date": "2020-08-17T22:41:50.513497",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg001"
@@ -14247,7 +14247,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.332519",
+        "dc:date": "2020-08-17T22:41:50.513504",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg002"
@@ -14258,7 +14258,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.332522",
+        "dc:date": "2020-08-17T22:41:50.513507",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg003"
@@ -14269,7 +14269,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.332525",
+        "dc:date": "2020-08-17T22:41:50.51351",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg004"
@@ -14280,7 +14280,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333565",
+        "dc:date": "2020-08-17T22:41:50.514515",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg005"
@@ -14291,7 +14291,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333572",
+        "dc:date": "2020-08-17T22:41:50.514521",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg006"
@@ -14302,7 +14302,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333575",
+        "dc:date": "2020-08-17T22:41:50.514524",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg007"
@@ -14313,7 +14313,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333583",
+        "dc:date": "2020-08-17T22:41:50.514527",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg008"
@@ -14324,7 +14324,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333587",
+        "dc:date": "2020-08-17T22:41:50.51453",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg009"
@@ -14335,7 +14335,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.33359",
+        "dc:date": "2020-08-17T22:41:50.514535",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tg010"
@@ -14346,7 +14346,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333593",
+        "dc:date": "2020-08-17T22:41:50.514538",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin01"
@@ -14357,7 +14357,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.333597",
+        "dc:date": "2020-08-17T22:41:50.514542",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin02"
@@ -14368,7 +14368,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.3336",
+        "dc:date": "2020-08-17T22:41:50.514545",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tin03"
@@ -14379,7 +14379,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.334526",
+        "dc:date": "2020-08-17T22:41:50.515494",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp020"
@@ -14390,7 +14390,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335371",
+        "dc:date": "2020-08-17T22:41:50.516393",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp021"
@@ -14401,7 +14401,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335378",
+        "dc:date": "2020-08-17T22:41:50.516401",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp046"
@@ -14412,7 +14412,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335381",
+        "dc:date": "2020-08-17T22:41:50.516404",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp049"
@@ -14423,7 +14423,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335384",
+        "dc:date": "2020-08-17T22:41:50.516407",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tp050"
@@ -14434,7 +14434,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335388",
+        "dc:date": "2020-08-17T22:41:50.51641",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra01"
@@ -14445,7 +14445,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335391",
+        "dc:date": "2020-08-17T22:41:50.516413",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra02"
@@ -14456,7 +14456,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335393",
+        "dc:date": "2020-08-17T22:41:50.516416",
         "earl:outcome": "earl:failed"
       },
       "earl:test": "https://w3c.github.io/json-ld-framing/tests/frame-manifest#tra03"
@@ -14467,7 +14467,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.335942",
+        "dc:date": "2020-08-17T22:41:50.517386",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test001"
@@ -14478,7 +14478,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.336286",
+        "dc:date": "2020-08-17T22:41:50.517736",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test002"
@@ -14489,7 +14489,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.336566",
+        "dc:date": "2020-08-17T22:41:50.518013",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test003"
@@ -14500,7 +14500,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.336904",
+        "dc:date": "2020-08-17T22:41:50.518328",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test004"
@@ -14511,7 +14511,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.337168",
+        "dc:date": "2020-08-17T22:41:50.518594",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test005"
@@ -14522,7 +14522,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.337433",
+        "dc:date": "2020-08-17T22:41:50.518848",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test006"
@@ -14533,7 +14533,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.337705",
+        "dc:date": "2020-08-17T22:41:50.519109",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test007"
@@ -14544,7 +14544,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.338006",
+        "dc:date": "2020-08-17T22:41:50.519381",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test008"
@@ -14555,7 +14555,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.338366",
+        "dc:date": "2020-08-17T22:41:50.519679",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test009"
@@ -14566,7 +14566,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.338625",
+        "dc:date": "2020-08-17T22:41:50.519936",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test010"
@@ -14577,7 +14577,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.338913",
+        "dc:date": "2020-08-17T22:41:50.52019",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test011"
@@ -14588,7 +14588,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.339202",
+        "dc:date": "2020-08-17T22:41:50.520456",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test012"
@@ -14599,7 +14599,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.339563",
+        "dc:date": "2020-08-17T22:41:50.520777",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test013"
@@ -14610,7 +14610,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.339859",
+        "dc:date": "2020-08-17T22:41:50.521065",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test014"
@@ -14621,7 +14621,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.339917",
+        "dc:date": "2020-08-17T22:41:50.521121",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test015"
@@ -14632,7 +14632,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.340192",
+        "dc:date": "2020-08-17T22:41:50.521392",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test016"
@@ -14643,7 +14643,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.340336",
+        "dc:date": "2020-08-17T22:41:50.521534",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test017"
@@ -14654,7 +14654,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.340495",
+        "dc:date": "2020-08-17T22:41:50.521681",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test018"
@@ -14665,7 +14665,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.340751",
+        "dc:date": "2020-08-17T22:41:50.521908",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test019"
@@ -14676,7 +14676,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.341059",
+        "dc:date": "2020-08-17T22:41:50.522185",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test020"
@@ -14687,7 +14687,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.341393",
+        "dc:date": "2020-08-17T22:41:50.522464",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test021"
@@ -14698,7 +14698,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.341774",
+        "dc:date": "2020-08-17T22:41:50.522781",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test022"
@@ -14709,7 +14709,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.342143",
+        "dc:date": "2020-08-17T22:41:50.523092",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test023"
@@ -14720,7 +14720,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.342491",
+        "dc:date": "2020-08-17T22:41:50.523462",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test024"
@@ -14731,7 +14731,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.343133",
+        "dc:date": "2020-08-17T22:41:50.5238",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test025"
@@ -14742,7 +14742,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.343615",
+        "dc:date": "2020-08-17T22:41:50.524248",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test026"
@@ -14753,7 +14753,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.343984",
+        "dc:date": "2020-08-17T22:41:50.524623",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test027"
@@ -14764,7 +14764,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.344391",
+        "dc:date": "2020-08-17T22:41:50.525026",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test028"
@@ -14775,7 +14775,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.344751",
+        "dc:date": "2020-08-17T22:41:50.525367",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test029"
@@ -14786,7 +14786,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.345075",
+        "dc:date": "2020-08-17T22:41:50.525706",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test030"
@@ -14797,7 +14797,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.345368",
+        "dc:date": "2020-08-17T22:41:50.526017",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test031"
@@ -14808,7 +14808,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.345778",
+        "dc:date": "2020-08-17T22:41:50.526338",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test032"
@@ -14819,7 +14819,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.346142",
+        "dc:date": "2020-08-17T22:41:50.526638",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test033"
@@ -14830,7 +14830,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.349265",
+        "dc:date": "2020-08-17T22:41:50.52699",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test034"
@@ -14841,7 +14841,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.349619",
+        "dc:date": "2020-08-17T22:41:50.527264",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test035"
@@ -14852,7 +14852,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.349958",
+        "dc:date": "2020-08-17T22:41:50.527436",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test036"
@@ -14863,7 +14863,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.350164",
+        "dc:date": "2020-08-17T22:41:50.527673",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test037"
@@ -14874,7 +14874,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.350418",
+        "dc:date": "2020-08-17T22:41:50.527836",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test038"
@@ -14885,7 +14885,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.350588",
+        "dc:date": "2020-08-17T22:41:50.527992",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test039"
@@ -14896,7 +14896,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.350814",
+        "dc:date": "2020-08-17T22:41:50.528213",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test040"
@@ -14907,7 +14907,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.350994",
+        "dc:date": "2020-08-17T22:41:50.528388",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test041"
@@ -14918,7 +14918,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.351171",
+        "dc:date": "2020-08-17T22:41:50.528562",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test042"
@@ -14929,7 +14929,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.35136",
+        "dc:date": "2020-08-17T22:41:50.528767",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test043"
@@ -14940,7 +14940,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.358139",
+        "dc:date": "2020-08-17T22:41:50.535504",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test044"
@@ -14951,7 +14951,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.364643",
+        "dc:date": "2020-08-17T22:41:50.542402",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test045"
@@ -14962,7 +14962,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.37073",
+        "dc:date": "2020-08-17T22:41:50.549267",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test046"
@@ -14973,7 +14973,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.371299",
+        "dc:date": "2020-08-17T22:41:50.549602",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test047"
@@ -14984,7 +14984,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.371667",
+        "dc:date": "2020-08-17T22:41:50.54991",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test048"
@@ -14995,7 +14995,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.371726",
+        "dc:date": "2020-08-17T22:41:50.549972",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test049"
@@ -15006,7 +15006,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.372091",
+        "dc:date": "2020-08-17T22:41:50.550258",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test050"
@@ -15017,7 +15017,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.372327",
+        "dc:date": "2020-08-17T22:41:50.550591",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test051"
@@ -15028,7 +15028,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.372533",
+        "dc:date": "2020-08-17T22:41:50.550943",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test052"
@@ -15039,7 +15039,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.372855",
+        "dc:date": "2020-08-17T22:41:50.551372",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test053"
@@ -15050,7 +15050,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.373296",
+        "dc:date": "2020-08-17T22:41:50.551718",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test054"
@@ -15061,7 +15061,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.373544",
+        "dc:date": "2020-08-17T22:41:50.552083",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test055"
@@ -15072,7 +15072,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.37377",
+        "dc:date": "2020-08-17T22:41:50.552302",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test056"
@@ -15083,7 +15083,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.37408",
+        "dc:date": "2020-08-17T22:41:50.552555",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test060"
@@ -15094,7 +15094,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.374254",
+        "dc:date": "2020-08-17T22:41:50.552763",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test061"
@@ -15105,7 +15105,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.374401",
+        "dc:date": "2020-08-17T22:41:50.553027",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urgna2012#test062"
@@ -15116,7 +15116,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.374904",
+        "dc:date": "2020-08-17T22:41:50.553631",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test001"
@@ -15127,7 +15127,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.375064",
+        "dc:date": "2020-08-17T22:41:50.553834",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test002"
@@ -15138,7 +15138,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.375225",
+        "dc:date": "2020-08-17T22:41:50.554021",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test003"
@@ -15149,7 +15149,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.375425",
+        "dc:date": "2020-08-17T22:41:50.554199",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test004"
@@ -15160,7 +15160,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.375669",
+        "dc:date": "2020-08-17T22:41:50.554384",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test005"
@@ -15171,7 +15171,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.375857",
+        "dc:date": "2020-08-17T22:41:50.554618",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test006"
@@ -15182,7 +15182,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.376015",
+        "dc:date": "2020-08-17T22:41:50.554817",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test007"
@@ -15193,7 +15193,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.37623",
+        "dc:date": "2020-08-17T22:41:50.555008",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test008"
@@ -15204,7 +15204,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.376452",
+        "dc:date": "2020-08-17T22:41:50.555232",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test009"
@@ -15215,7 +15215,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.376623",
+        "dc:date": "2020-08-17T22:41:50.555397",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test010"
@@ -15226,7 +15226,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.376828",
+        "dc:date": "2020-08-17T22:41:50.555544",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test011"
@@ -15237,7 +15237,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.377063",
+        "dc:date": "2020-08-17T22:41:50.555691",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test012"
@@ -15248,7 +15248,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.377306",
+        "dc:date": "2020-08-17T22:41:50.555849",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test013"
@@ -15259,7 +15259,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.377611",
+        "dc:date": "2020-08-17T22:41:50.556034",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test014"
@@ -15270,7 +15270,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.377661",
+        "dc:date": "2020-08-17T22:41:50.556108",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test015"
@@ -15281,7 +15281,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.377828",
+        "dc:date": "2020-08-17T22:41:50.556361",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test016"
@@ -15292,7 +15292,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.378009",
+        "dc:date": "2020-08-17T22:41:50.556573",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test017"
@@ -15303,7 +15303,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.378278",
+        "dc:date": "2020-08-17T22:41:50.556794",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test018"
@@ -15314,7 +15314,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.378553",
+        "dc:date": "2020-08-17T22:41:50.557019",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test019"
@@ -15325,7 +15325,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.378764",
+        "dc:date": "2020-08-17T22:41:50.557218",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test020"
@@ -15336,7 +15336,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.37903",
+        "dc:date": "2020-08-17T22:41:50.557407",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test021"
@@ -15347,7 +15347,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.379253",
+        "dc:date": "2020-08-17T22:41:50.557635",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test022"
@@ -15358,7 +15358,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.379862",
+        "dc:date": "2020-08-17T22:41:50.557858",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test023"
@@ -15369,7 +15369,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.380163",
+        "dc:date": "2020-08-17T22:41:50.558131",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test024"
@@ -15380,7 +15380,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.380435",
+        "dc:date": "2020-08-17T22:41:50.558396",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test025"
@@ -15391,7 +15391,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.380738",
+        "dc:date": "2020-08-17T22:41:50.558692",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test026"
@@ -15402,7 +15402,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.381052",
+        "dc:date": "2020-08-17T22:41:50.558958",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test027"
@@ -15413,7 +15413,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.381368",
+        "dc:date": "2020-08-17T22:41:50.559233",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test028"
@@ -15424,7 +15424,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.38165",
+        "dc:date": "2020-08-17T22:41:50.559512",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test029"
@@ -15435,7 +15435,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.381841",
+        "dc:date": "2020-08-17T22:41:50.55974",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test030"
@@ -15446,7 +15446,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.382036",
+        "dc:date": "2020-08-17T22:41:50.559948",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test031"
@@ -15457,7 +15457,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.382194",
+        "dc:date": "2020-08-17T22:41:50.560118",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test032"
@@ -15468,7 +15468,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.38237",
+        "dc:date": "2020-08-17T22:41:50.560308",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test033"
@@ -15479,7 +15479,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.382563",
+        "dc:date": "2020-08-17T22:41:50.560559",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test034"
@@ -15490,7 +15490,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.382797",
+        "dc:date": "2020-08-17T22:41:50.560816",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test035"
@@ -15501,7 +15501,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.383022",
+        "dc:date": "2020-08-17T22:41:50.561029",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test036"
@@ -15512,7 +15512,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.383217",
+        "dc:date": "2020-08-17T22:41:50.561255",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test037"
@@ -15523,7 +15523,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.383433",
+        "dc:date": "2020-08-17T22:41:50.561441",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test038"
@@ -15534,7 +15534,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.383647",
+        "dc:date": "2020-08-17T22:41:50.561626",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test039"
@@ -15545,7 +15545,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.383897",
+        "dc:date": "2020-08-17T22:41:50.561843",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test040"
@@ -15556,7 +15556,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.384183",
+        "dc:date": "2020-08-17T22:41:50.562376",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test041"
@@ -15567,7 +15567,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.384398",
+        "dc:date": "2020-08-17T22:41:50.562761",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test042"
@@ -15578,7 +15578,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.384563",
+        "dc:date": "2020-08-17T22:41:50.562943",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test043"
@@ -15589,7 +15589,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.391696",
+        "dc:date": "2020-08-17T22:41:50.570332",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test044"
@@ -15600,7 +15600,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.399149",
+        "dc:date": "2020-08-17T22:41:50.578024",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test045"
@@ -15611,7 +15611,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.406583",
+        "dc:date": "2020-08-17T22:41:50.585677",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test046"
@@ -15622,7 +15622,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.406993",
+        "dc:date": "2020-08-17T22:41:50.586072",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test047"
@@ -15633,7 +15633,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.407424",
+        "dc:date": "2020-08-17T22:41:50.586353",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test048"
@@ -15644,7 +15644,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.407489",
+        "dc:date": "2020-08-17T22:41:50.586414",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test049"
@@ -15655,7 +15655,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.40785",
+        "dc:date": "2020-08-17T22:41:50.586622",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test050"
@@ -15666,7 +15666,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.408935",
+        "dc:date": "2020-08-17T22:41:50.586943",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test051"
@@ -15677,7 +15677,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.409156",
+        "dc:date": "2020-08-17T22:41:50.587261",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test052"
@@ -15688,7 +15688,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.409598",
+        "dc:date": "2020-08-17T22:41:50.587627",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test053"
@@ -15699,7 +15699,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.410061",
+        "dc:date": "2020-08-17T22:41:50.588144",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test054"
@@ -15710,7 +15710,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.410388",
+        "dc:date": "2020-08-17T22:41:50.588438",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test055"
@@ -15721,7 +15721,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.410691",
+        "dc:date": "2020-08-17T22:41:50.588635",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test056"
@@ -15732,7 +15732,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.411144",
+        "dc:date": "2020-08-17T22:41:50.589117",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test057"
@@ -15743,7 +15743,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.411657",
+        "dc:date": "2020-08-17T22:41:50.589651",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test058"
@@ -15754,7 +15754,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.412235",
+        "dc:date": "2020-08-17T22:41:50.590251",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test059"
@@ -15765,7 +15765,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.41259",
+        "dc:date": "2020-08-17T22:41:50.590576",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test060"
@@ -15776,7 +15776,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.412867",
+        "dc:date": "2020-08-17T22:41:50.590764",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test061"
@@ -15787,7 +15787,7 @@
       "earl:mode": "earl:automatic",
       "earl:result": {
         "@type": "earl:TestResult",
-        "dc:date": "2020-04-06T17:15:23.413087",
+        "dc:date": "2020-08-17T22:41:50.590973",
         "earl:outcome": "earl:passed"
       },
       "earl:test": "manifest-urdna2015#test062"

--- a/ld/processor_test.go
+++ b/ld/processor_test.go
@@ -96,6 +96,8 @@ func NewMockServer(base string, testFolder string) *MockServer {
 				if contentType == "" {
 					if strings.HasSuffix(u, ".jsonld") {
 						contentType = "application/ld+json"
+					} else if strings.HasSuffix(u, ".html") {
+						contentType = "text/html"
 					} else {
 						contentType = "application/json"
 					}

--- a/ld/skip_test.go
+++ b/ld/skip_test.go
@@ -31,8 +31,6 @@ var skippedTests = map[string][]string{
 	},
 	"testdata/remote-doc-manifest.jsonld": {
 		"#t0013", // HTML documents aren't supported yet
-		"#tla01", // HTML documents aren't supported yet
-		"#tla05", // HTML documents aren't supported yet
 	},
 	"testdata/toRdf-manifest.jsonld": {
 		"#tc032", // TODO


### PR DESCRIPTION
This PR fixes #37.