### PR TITLE
Check JSON Literal support against official test suite

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,5 +5,6 @@ This library was originally written by Stan Nazarenko (@kazarena) with Pull Requ
 * Koala Yeung (@yookoala)
 * Koushik Roy (@Koshroy)
 * Joel Gustafson (@joeltg)
+* Dmitriy Kinoshenko (@kdimak)
 
 All future contributors will be recorded in this file.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Good coverage, except:
 
 Good coverage, except:
 
-- JSON literals (`@json`) aren't supported
+- partial support for JSON literals (`@json`)
 - `rdfDirection` option is not yet supported (including _i18n-datatype_ and _compound-literal_ forms)
 
 #### HTML based processing

--- a/ld/internal/jsoncanonicalizer/es6numfmt.go
+++ b/ld/internal/jsoncanonicalizer/es6numfmt.go
@@ -39,14 +39,14 @@ func NumberToJSON(ieeeF64 float64) (res string, err error) {
 	}
 
 	// Special case: eliminate "-0" as mandated by the ES6-JSON/JCS specifications
-	if ieeeF64 == 0 {  // Right, this line takes both -0 and 0
+	if ieeeF64 == 0 { // Right, this line takes both -0 and 0
 		return "0", nil
 	}
 
 	// Deal with the sign separately
 	var sign string = ""
 	if ieeeF64 < 0 {
-		ieeeF64 =-ieeeF64
+		ieeeF64 = -ieeeF64
 		sign = "-"
 	}
 
@@ -70,13 +70,13 @@ func NumberToJSON(ieeeF64 float64) (res string, err error) {
 			es6Formatted = gform
 		}
 		// Go outputs "1e+09" which must be rewritten as "1e+9"
-		if es6Formatted[exponent + 2] == '0' {
-			es6Formatted = es6Formatted[:exponent + 2] + es6Formatted[exponent + 3:]
+		if es6Formatted[exponent+2] == '0' {
+			es6Formatted = es6Formatted[:exponent+2] + es6Formatted[exponent+3:]
 		}
 	} else if strings.IndexByte(es6Formatted, '.') < 0 && len(es6Formatted) >= 12 {
 		i := len(es6Formatted)
-		for es6Formatted[i - 1] == '0' {
-			i--;
+		for es6Formatted[i-1] == '0' {
+			i--
 		}
 		if i != len(es6Formatted) {
 			fix := strconv.FormatFloat(ieeeF64, 'f', 0, 64)
@@ -84,7 +84,7 @@ func NumberToJSON(ieeeF64 float64) (res string, err error) {
 				// "f" with precision 0 occasionally produces another result which also is
 				// the correct one although it must be rounded to match the -1 precision
 				// (which fortunately seems to be correct with respect to trailing zeroes)
-				es6Formatted = fix[:i - 1] + string(fix[i - 1] + 1) + es6Formatted[i:]
+				es6Formatted = fix[:i-1] + string(fix[i-1]+1) + es6Formatted[i:]
 			}
 		}
 	}

--- a/ld/internal/jsoncanonicalizer/jsoncanonicalizer.go
+++ b/ld/internal/jsoncanonicalizer/jsoncanonicalizer.go
@@ -29,17 +29,17 @@ import (
 )
 
 type nameValueType struct {
-	name string
+	name    string
 	sortKey []uint16
-	value string
+	value   string
 }
 
 // JSON standard escapes (modulo \u)
-var asciiEscapes  = []byte{'\\', '"', 'b',  'f',  'n',  'r',  't'}
+var asciiEscapes = []byte{'\\', '"', 'b', 'f', 'n', 'r', 't'}
 var binaryEscapes = []byte{'\\', '"', '\b', '\f', '\n', '\r', '\t'}
 
 // JSON literals
-var literals      = []string{"true", "false", "null"}
+var literals = []string{"true", "false", "null"}
 
 func Transform(jsonData []byte) (result []byte, e error) {
 
@@ -90,7 +90,7 @@ func Transform(jsonData []byte) (result []byte, e error) {
 		for {
 			c := nextChar()
 			if isWhiteSpace(c) {
-				continue;
+				continue
 			}
 			return c
 		}
@@ -160,8 +160,8 @@ func Transform(jsonData []byte) (result []byte, e error) {
 				nextChar()
 				break
 			}
-			if (c == '"') {
-				break;
+			if c == '"' {
+				break
 			}
 			if c < ' ' {
 				setError("Unterminated string literal")
@@ -215,7 +215,7 @@ func Transform(jsonData []byte) (result []byte, e error) {
 		for globalError == nil {
 			c := testNextNonWhiteSpaceChar()
 			if c == ',' || c == ']' || c == '}' {
-				break;
+				break
 			}
 			c = nextChar()
 			if isWhiteSpace(c) {
@@ -314,7 +314,7 @@ func Transform(jsonData []byte) (result []byte, e error) {
 			scanFor('"')
 			rawUTF8 := parseQuotedString()
 			if globalError != nil {
-				break;
+				break
 			}
 			// Sort keys on UTF-16 code units
 			// Since UTF-8 doesn't have endianess this is just a value transformation
@@ -370,7 +370,7 @@ func Transform(jsonData []byte) (result []byte, e error) {
 	for index < jsonDataLength {
 		if !isWhiteSpace(jsonData[index]) {
 			setError("Improperly terminated JSON object")
-			break;
+			break
 		}
 		index++
 	}

--- a/ld/rdf_compare_test.go
+++ b/ld/rdf_compare_test.go
@@ -3,7 +3,6 @@ package ld_test
 import (
 	"log"
 	"sort"
-	"strconv"
 	"strings"
 
 	. "github.com/piprate/json-gold/ld"
@@ -71,7 +70,9 @@ func mapBlankNodes(quads []*Quad, actualBlankNodes []string, mappedBlankNodes []
 
 func sortNQuads(input string) string {
 	temp := strings.Split(input, "\n")
-	temp = temp[:len(temp)-1]
+	if temp[len(temp)-1] == "" {
+		temp = temp[:len(temp)-1]
+	}
 	sort.Strings(temp)
 	temp = append(temp, "")
 	return strings.Join(temp, "\n")
@@ -92,10 +93,16 @@ func Isomorphic(expectedStr, actualStr string) bool {
 
 	serializer := &NQuadRDFSerializer{}
 
-	expectedStr, _ = strconv.Unquote(expectedStr)
-	actualStr, _ = strconv.Unquote(actualStr)
-	expectedDS, _ := serializer.Parse(expectedStr)
-	actualDS, _ := serializer.Parse(actualStr)
+	expectedDS, err := serializer.Parse(expectedStr)
+	if err != nil {
+		log.Printf("Error when parsing expected quads: %s\n", err.Error())
+		return false
+	}
+	actualDS, err := serializer.Parse(actualStr)
+	if err != nil {
+		log.Printf("Error when parsing actual quads: %s\n", err.Error())
+		return false
+	}
 
 	if len(expectedDS.Graphs) != len(actualDS.Graphs) {
 		log.Println("Number of graphs doesn't match")

--- a/ld/skip_test.go
+++ b/ld/skip_test.go
@@ -35,6 +35,27 @@ var skippedTests = map[string][]string{
 	"testdata/toRdf-manifest.jsonld": {
 		"#tc032", // TODO
 		"#tc033", // TODO
+		"#tdi09", // No support for i18n-datatype yet
+		"#tdi10", // No support for i18n-datatype yet
+		"#tdi11", // No support for compound-literal yet
+		"#tdi12", // No support for compound-literal yet
+		"#te075", // No support for GeneralizedRdf
+		"#te085", // test passes, bug in isomorphism check
+		"#te086", // test passes, bug in isomorphism check
+		"#te087", // test passes, bug in isomorphism check
+		"#te111", // TODO
+		"#te112", // TODO
+		"#tjs03", // TODO numeric format
+		"#tjs07",
+		"#tjs08",
+		"#tjs14",
+		"#tjs15",
+		"#tjs16",
+		"#tjs17",
+		"#tjs18",
+		"#tjs21",
+		"#tjs22",
+		"#tjs23",
 		"#tec02", // TODO
 		"#ter52", // TODO
 
@@ -43,6 +64,7 @@ var skippedTests = map[string][]string{
 		"#tpr28", // Skipped in Expand test suite
 		"#tpr38", // TODO
 		"#tpr39", // TODO
+		"#ttn02", // TODO
 	},
 	"testdata/html-manifest.jsonld": {
 		"#t", // HTML inputs not supported yet
@@ -92,6 +114,10 @@ var skippedTests = map[string][]string{
 		"#tp050",
 		"#tra",
 	},
-	"testdata/normalization/manifest-urgna2012.jsonld": {},
-	"testdata/normalization/manifest-urdna2015.jsonld": {},
+	"testdata/normalization/manifest-urgna2012.jsonld": {
+		"manifest-urgna2012#test060",
+	},
+	"testdata/normalization/manifest-urdna2015.jsonld": {
+		"manifest-urdna2015#test060",
+	},
 }


### PR DESCRIPTION
Re: #35.

@kdimak, I had to fix the N-Quad comparison logic before testing the new JSON Canonicalisation against the official test suite in [ld/testdata/toRdf-manifest.jsonld](https://github.com/piprate/json-gold/blob/master/ld/testdata/toRdf-manifest.jsonld). I realised some tests were passing due to an issue with the quad comparison, while in fact they failed.

For your information, out of 23 tests for JSON literals (toRDF algorithm), the following tests are still failing:

#tjs07
#tjs08
#tjs14
#tjs15
#tjs16
#tjs17
#tjs18
#tjs21
#tjs22
#tjs23

(marked as to be skipped)

It's still better coverage than we had before, so thank you for the PR. Some of these tests are pretty easy to fix. I'll do it when I have time.

@troyronda @rolsonquadras