### PR TITLE
~3x performance improvement by optimizing code hotspots wrt regexes

### DIFF
--- a/ld/utils.go
+++ b/ld/utils.go
@@ -17,6 +17,7 @@ package ld
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -145,7 +146,12 @@ func MergeValue(obj map[string]interface{}, key string, value interface{}) {
 
 // IsAbsoluteIri returns true if the given value is an absolute IRI, false if not.
 func IsAbsoluteIri(value string) bool {
-	return ParseURL(value).Protocol != ""
+	if strings.HasPrefix(value, "_:") {
+		return true
+	}
+
+	u, err := url.Parse(value)
+	return err == nil && u.IsAbs()
 }
 
 // IsSubject returns true if the given value is a subject with properties.


### PR DESCRIPTION
two more bottlenecks discovered:
1. `IsAbsoluteUrl` used the `urls.ParseURL` to determine if it had a protocol or not. The regex in that ParseURL function is quite expensive, especially when used 1000+ times in `createTermDefinition` with a schema.org Context - I used the logic defined in jsonld.js - by checking if it was an absolute url (via the go `url` package) or a blank node (starts with `_:`) - this passes all test and cuts the expansion of 100 schema.org json ld documents from 13 seconds to ~8 seconds.

2. the term regex that I extracted in PR #42 was called so often, that I looked into simplifying. This regex simply checks for the existence of about half a dozen characters on the suffix of the term. I simplified this into a switch statement and further dropped processing times of the same 100 documents from 8 seconds to ~5 seconds

really just using `pprof` in my application to hunt down hotspots. There are a few more, but getting into dimension return territory at this point

- andrew