### PR TITLE
feat: add support for SafeMode on expandObject

### DIFF
--- a/ld/api_expand.go
+++ b/ld/api_expand.go
@@ -359,7 +359,11 @@ func (api *JsonLdApi) expandObject(activeCtx *Context, activeProperty string, ex
 		var expandedValue interface{}
 		// 7.3)
 		if expandedProperty == "" || (!strings.Contains(expandedProperty, ":") && !IsKeyword(expandedProperty)) {
-			continue
+			if activeCtx.options != nil && activeCtx.options.SafeMode {
+				return NewJsonLdError(InvalidInput, "property didn't expand into absolute IRI or keyword")
+			} else {
+				continue
+			}
 		}
 		// 7.4)
 		if IsKeyword(expandedProperty) {

--- a/ld/api_expand.go
+++ b/ld/api_expand.go
@@ -360,7 +360,7 @@ func (api *JsonLdApi) expandObject(activeCtx *Context, activeProperty string, ex
 		// 7.3)
 		if expandedProperty == "" || (!strings.Contains(expandedProperty, ":") && !IsKeyword(expandedProperty)) {
 			if activeCtx.options != nil && activeCtx.options.SafeMode {
-				return NewJsonLdError(InvalidInput, "property didn't expand into absolute IRI or keyword")
+				return NewJsonLdError(InvalidProperty, "Dropping property that did not expand into an absolute IRI or keyword.")
 			} else {
 				continue
 			}

--- a/ld/errors.go
+++ b/ld/errors.go
@@ -78,13 +78,14 @@ const (
 	IRIConfusedWithPrefix       ErrorCode = "IRI confused with prefix"
 
 	// non spec related errors
-	SyntaxError    ErrorCode = "syntax error"
-	NotImplemented ErrorCode = "not implemented"
-	UnknownFormat  ErrorCode = "unknown format"
-	InvalidInput   ErrorCode = "invalid input"
-	ParseError     ErrorCode = "parse error"
-	IOError        ErrorCode = "io error"
-	UnknownError   ErrorCode = "unknown error"
+	SyntaxError     ErrorCode = "syntax error"
+	NotImplemented  ErrorCode = "not implemented"
+	UnknownFormat   ErrorCode = "unknown format"
+	InvalidInput    ErrorCode = "invalid input"
+	ParseError      ErrorCode = "parse error"
+	IOError         ErrorCode = "io error"
+	InvalidProperty ErrorCode = "invalid property"
+	UnknownError    ErrorCode = "unknown error"
 )
 
 func (e JsonLdError) Error() string {

--- a/ld/options.go
+++ b/ld/options.go
@@ -65,6 +65,7 @@ type JsonLdOptions struct {
 	Algorithm     string
 	UseNamespaces bool
 	OutputForm    string
+	SafeMode      bool
 }
 
 // NewJsonLdOptions creates and returns new instance of JsonLdOptions with the given base.
@@ -88,6 +89,7 @@ func NewJsonLdOptions(base string) *JsonLdOptions {
 		Algorithm:             "URGNA2012",
 		UseNamespaces:         false,
 		OutputForm:            "",
+		SafeMode:              false,
 	}
 }
 


### PR DESCRIPTION
closes #59

## Summary

When SafeMode is true, expandObject will return an error if a property doesn't expand into IRI.

## Basic example

```go
proc := ld.NewJsonLdProcessor()
options := ld.NewJsonLdOptions("")
options.SafeMode := true

doc := map[string]interface{}{
    "@context": "https://json-ld.org/contexts/person.jsonld",
    "@id": "http://dbpedia.org/resource/John_Lennon",
    "name": "John Lennon",
    "born": "1940-10-09",
    "sex": "male",
}

// "sex" property doesn't expand into into absolute IRI or keyword, will return error
expanded, err = proc.Expand(doc, options)
```

## Motivation

Based on [this warning](https://github.com/setl/rdf-urdna/tree/master/jsonld-warnings), if a property that doesn't expand dropped silently, two different JSON can have exact same signature. Additional data is not included in normalization. [JSON-LD Playground](https://json-ld.org/playground/) also has safe mode option, which behave similarly with this PR.

## Checks

- [x] Passes `make test`
