### PR TITLE
Bugfix: copy SafeMode in JsonLdOptions.Copy

### DIFF
--- a/ld/options.go
+++ b/ld/options.go
@@ -115,5 +115,6 @@ func (opt *JsonLdOptions) Copy() *JsonLdOptions {
 		Algorithm:             opt.Algorithm,
 		UseNamespaces:         opt.UseNamespaces,
 		OutputForm:            opt.OutputForm,
+		SafeMode:              opt.SafeMode,
 	}
 }

--- a/ld/options_test.go
+++ b/ld/options_test.go
@@ -1,8 +1,9 @@
 package ld
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestJsonLdOptions_Copy(t *testing.T) {

--- a/ld/options_test.go
+++ b/ld/options_test.go
@@ -1,0 +1,31 @@
+package ld
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestJsonLdOptions_Copy(t *testing.T) {
+	expected := JsonLdOptions{
+		Base:                  "base",
+		CompactArrays:         true,
+		ProcessingMode:        JsonLd_1_1,
+		DocumentLoader:        NewDefaultDocumentLoader(nil),
+		Embed:                 EmbedLast,
+		Explicit:              true,
+		RequireAll:            true,
+		FrameDefault:          true,
+		OmitDefault:           true,
+		OmitGraph:             true,
+		UseRdfType:            true,
+		UseNativeTypes:        true,
+		ProduceGeneralizedRdf: true,
+		InputFormat:           "input",
+		Format:                "format",
+		Algorithm:             AlgorithmURGNA2012,
+		UseNamespaces:         true,
+		OutputForm:            "output",
+		SafeMode:              true,
+	}
+	assert.Equal(t, expected, *expected.Copy())
+}


### PR DESCRIPTION
## Summary

Also copy `SafeMode`, introduced in v0.5.0, in `JsonLdOptions.Copy`.

## Basic example

This now fails to expand with safe mode enabled:

```go
processor := ld.NewJsonLdProcessor()
options := ld.NewJsonLdOptions("")
options.SafeMode = true

_, err := processor.Expand(input, options)
```

## Motivation

Example above, given input with fields not defined in context, should fail.

## Checks

- [x] Passes `make test`
