### PR TITLE
context.parse now returns underlying document loader error

### DIFF
--- a/ld/context.go
+++ b/ld/context.go
@@ -191,7 +191,7 @@ func (c *Context) parse(localContext interface{}, remoteContexts []string, parsi
 			rd, err := c.options.DocumentLoader.LoadDocument(uri)
 			if err != nil {
 				return nil, NewJsonLdError(LoadingRemoteContextFailed,
-					fmt.Sprintf("Dereferencing a URL did not result in a valid JSON-LD context: %s", uri))
+					fmt.Errorf("dereferencing a URL did not result in a valid JSON-LD context (%s): %w", uri, err))
 			}
 			remoteContextMap, isMap := rd.Document.(map[string]interface{})
 			context, hasContextKey := remoteContextMap["@context"]
@@ -252,7 +252,7 @@ func (c *Context) parse(localContext interface{}, remoteContexts []string, parsi
 			rd, err := c.options.DocumentLoader.LoadDocument(uri)
 			if err != nil {
 				return nil, NewJsonLdError(LoadingRemoteContextFailed,
-					fmt.Sprintf("Dereferencing a URL did not result in a valid JSON-LD context: %s", uri))
+					fmt.Errorf("dereferencing a URL did not result in a valid JSON-LD context (%s): %w", uri, err))
 			}
 			importCtxDocMap, isMap := rd.Document.(map[string]interface{})
 			context, hasContextKey := importCtxDocMap["@context"]

--- a/ld/context_test.go
+++ b/ld/context_test.go
@@ -1,0 +1,43 @@
+package ld
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContext_Parse(t *testing.T) {
+	expectedError := errors.New("failed")
+	opts := NewJsonLdOptions("")
+	opts.DocumentLoader = errorDocumentLoader{err: expectedError}
+
+	t.Run("DocumentLoader can't resolve @context URL", func(t *testing.T) {
+		ctx := NewContext(nil, opts)
+		_, err := ctx.Parse("http://example.org/foo.ldjson")
+		jsonLDError := new(JsonLdError)
+		require.ErrorAs(t, err, &jsonLDError)
+		assert.Equal(t, LoadingRemoteContextFailed, jsonLDError.Code)
+		assert.ErrorIs(t, err, expectedError, "DocumentLoader error is not wrapped")
+	})
+	t.Run("DocumentLoader can't resolve @import", func(t *testing.T) {
+		ctx := NewContext(nil, opts)
+		_, err := ctx.Parse(map[string]interface{}{
+			"@import": "http://example.org/foo.ldjson",
+		})
+		jsonLDError := new(JsonLdError)
+		require.ErrorAs(t, err, &jsonLDError)
+		assert.Equal(t, LoadingRemoteContextFailed, jsonLDError.Code)
+		assert.ErrorIs(t, err, expectedError, "DocumentLoader error is not wrapped")
+	})
+}
+
+type errorDocumentLoader struct {
+	err error
+}
+
+func (l errorDocumentLoader) LoadDocument(u string) (*RemoteDocument, error) {
+	return nil, l.err
+}

--- a/ld/errors.go
+++ b/ld/errors.go
@@ -95,6 +95,12 @@ func (e JsonLdError) Error() string {
 	return fmt.Sprintf("%v", e.Code)
 }
 
+// Unwrap returns JsonLdError.Details if it is an error, otherwise nil.
+func (e JsonLdError) Unwrap() error {
+	cause, _ := e.Details.(error)
+	return cause
+}
+
 // NewJsonLdError creates a new instance of JsonLdError.
 func NewJsonLdError(code ErrorCode, details interface{}) *JsonLdError { //nolint:stylecheck
 	return &JsonLdError{Code: code, Details: details}

--- a/ld/errors_test.go
+++ b/ld/errors_test.go
@@ -1,0 +1,21 @@
+package ld
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJsonLdError_Unwrap(t *testing.T) {
+	t.Run("Details is error", func(t *testing.T) {
+		err := errors.New("failed")
+		assert.Equal(t, err, NewJsonLdError(UnknownError, err).Unwrap())
+	})
+	t.Run("Details is not an error", func(t *testing.T) {
+		assert.Nil(t, NewJsonLdError(UnknownError, "failed").Unwrap())
+	})
+	t.Run("Details is nil", func(t *testing.T) {
+		assert.Nil(t, NewJsonLdError(UnknownError, nil).Unwrap())
+	})
+}


### PR DESCRIPTION
## Summary

When `Context.Parse` fails to resolve a remote document (through `@context` or `@imports`), it now wraps the error returned by the `DocumentLoader`. This allows applications to discern error situations.

## Basic example

Given a JSON-LD document with a URL in `@context`, when `DocumentLoader.LoadDocument` returns `HTTP 404 not found`, then `Context.Parse` should return the existing error, but with the loader error wrapped inside it.

## Motivation

- Currently, the `DocumentLoader` error is thrown away, which is bad practice.
- It allows applications to have specific error handling for specific error scenarios.

Our use case is as follows: we have a `DocumentLoader` (https://github.com/nuts-foundation/nuts-node/blob/master/jsonld/ldutils.go#L69) that restricts (for security reasons) the locations from which JSON-LD context documents can be resolved. When a JSON-LD document (a Verifiable Credential in our case) fails to process, we want to retry it later in case of a transport error. E.g., the server returned a non-OK status code, or was temporarily unavailable (due to maintenance/misconfiguration, etc). In other cases (URL not allowed) we just log it.

## Checks

- [x] Passes `make test`
