### PR TITLE
should return serializer error

### DIFF
--- a/ld/processor.go
+++ b/ld/processor.go
@@ -457,7 +457,10 @@ func (jldp *JsonLdProcessor) FromRDF(dataset interface{}, opts *JsonLdOptions) (
 
 func (jldp *JsonLdProcessor) fromRDF(input interface{}, opts *JsonLdOptions, serializer RDFSerializer) (interface{}, error) {
 
-	dataset, _ := serializer.Parse(input)
+	dataset, err := serializer.Parse(input)
+	if err != nil {
+		return nil, err
+	}
 
 	// convert from RDF
 	api := NewJsonLdApi()


### PR DESCRIPTION
## Summary

uncatched serializer error  will course crash

## Basic example

Frame with invalid type of schema.  for example, with `@context` `https://w3id.org/citizenship/v1` , change `PermanentResidentCard` to  `PermanentResidentCar`, program will crash

## Motivation

service use jsonld should not crash


