### PR TITLE
Fix #76: Nested @context definition returns an error

### DIFF
--- a/ld/context.go
+++ b/ld/context.go
@@ -218,6 +218,14 @@ func (c *Context) parse(localContext interface{}, remoteContexts []string, parsi
 			return nil, NewJsonLdError(InvalidLocalContext, context)
 		}
 
+		// dereference @context key if present
+		if nestedContext := contextMap["@context"]; nestedContext != nil {
+			contextMap, isMap = nestedContext.(map[string]interface{})
+			if !isMap {
+				return nil, NewJsonLdError(InvalidLocalContext, nestedContext)
+			}
+		}
+
 		pm, hasProcessingMode := c.values["processingMode"]
 
 		if versionValue, versionPresent := contextMap["@version"]; versionPresent {

--- a/ld/processor_test.go
+++ b/ld/processor_test.go
@@ -210,6 +210,12 @@ func TestSuite(t *testing.T) {
 		filepath.Join(testDir, "normalization", "manifest-urdna2015.jsonld"),
 	)
 
+	// extra tests that aren't covered by the official test suite
+
+	manifestList = append(manifestList,
+		filepath.Join(testDir, "extra-manifest.jsonld"),
+	)
+
 	dl := NewDefaultDocumentLoader(nil)
 	proc := NewJsonLdProcessor()
 	earlReport := NewEarlReport()

--- a/ld/processor_test.go
+++ b/ld/processor_test.go
@@ -202,17 +202,12 @@ func TestSuite(t *testing.T) {
 		manifestList = append(manifestList, filepath.Join(testDir, val.(string)))
 	}
 
-	// Framing and Normalisation test suites
-
 	manifestList = append(manifestList,
+		// Framing and Normalisation test suites
 		filepath.Join(testDir, "frame-manifest.jsonld"),
 		filepath.Join(testDir, "normalization", "manifest-urgna2012.jsonld"),
 		filepath.Join(testDir, "normalization", "manifest-urdna2015.jsonld"),
-	)
-
-	// extra tests that aren't covered by the official test suite
-
-	manifestList = append(manifestList,
+		// extra tests that aren't covered by the official test suite
 		filepath.Join(testDir, "extra-manifest.jsonld"),
 	)
 

--- a/ld/testdata/extra-manifest.jsonld
+++ b/ld/testdata/extra-manifest.jsonld
@@ -1,0 +1,18 @@
+{
+  "@context": ["context.jsonld", {"@base": "extra-manifest"}],
+  "@id": "",
+  "@type": "mf:Manifest",
+  "name": "Expansion",
+  "description": "JSON-LD Expansion tests.",
+  "baseIri": "https://w3c.github.io/json-ld-api/tests/",
+  "sequence": [
+    {
+      "@id": "#ext0001",
+      "@type": ["jld:PositiveEvaluationTest", "jld:ExpandTest"],
+      "name": "resolve nested contexts #76",
+      "purpose": "Ensure nested contexts are dereferenced",
+      "input": "extra/0001-in.jsonld",
+      "expect": "extra/0001-out.jsonld"
+    }
+  ]
+}

--- a/ld/testdata/extra/0001-in.jsonld
+++ b/ld/testdata/extra/0001-in.jsonld
@@ -1,0 +1,11 @@
+{
+  "@context": [
+    {
+      "@context": {
+         "PropertyValue": "http://schema.org/#PropertyValue"
+      }
+    }
+  ],
+  "@id":"https://foo.bar/baz",
+  "@type":"PropertyValue"
+}

--- a/ld/testdata/extra/0001-out.jsonld
+++ b/ld/testdata/extra/0001-out.jsonld
@@ -1,0 +1,8 @@
+[
+  {
+    "@id": "https://foo.bar/baz",
+    "@type": [
+      "http://schema.org/#PropertyValue"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

This change fixes #76.

The implementation was inspired by https://github.com/digitalbazaar/jsonld.js/blob/e2f6523b5c01f8d44a198e21e2b206586db4472e/lib/context.js#L148.

## Checks

- [x] Passes `make test`
