### PR TITLE
Fix GetCanonicalDouble for values between -1 and +1

### DIFF
--- a/ld/rdf_dataset.go
+++ b/ld/rdf_dataset.go
@@ -292,11 +292,11 @@ func (ds *RDFDataset) GetQuads(graphName string) []*Quad {
 	return ds.Graphs[graphName]
 }
 
-var canonicalDoubleRegEx = regexp.MustCompile(`(\d)0*E\+?0*(\d)`)
+var canonicalDoubleRegEx = regexp.MustCompile(`(\d)0*E\+?(-)?0*(\d)`)
 
 // GetCanonicalDouble returns a canonical string representation of a float64 number.
 func GetCanonicalDouble(v float64) string {
-	return canonicalDoubleRegEx.ReplaceAllString(fmt.Sprintf("%1.15E", v), "${1}E${2}")
+	return canonicalDoubleRegEx.ReplaceAllString(fmt.Sprintf("%1.15E", v), "${1}E${2}${3}")
 }
 
 var (

--- a/ld/rdf_dataset_test.go
+++ b/ld/rdf_dataset_test.go
@@ -23,4 +23,7 @@ import (
 
 func TestGetCanonicalDouble(t *testing.T) {
 	assert.Equal(t, "5.3E0", GetCanonicalDouble(5.3))
+	assert.Equal(t, "-7.5E1", GetCanonicalDouble(-75))
+	assert.Equal(t, "7.5E-1", GetCanonicalDouble(0.75))
+	assert.Equal(t, "-7.5E-1", GetCanonicalDouble(-0.75))
 }


### PR DESCRIPTION
## Summary

Looks like GetCanonicalDouble is supposed to work a little different. It seams for me the canonicalDoubleRegEx regexp is not expected numbers between 0 and 1. 

## Basic example

In current implementation `TestGetCanonicalDouble(0.75)` gives `7.500000000000000E-01`. I believe it should be `7.5E-1`.

## Checks

Tests in TestGetCanonicalDouble. 
