### PR TITLE
feat: improve performance and type-safety

### DIFF
--- a/ld/utils.go
+++ b/ld/utils.go
@@ -551,17 +551,7 @@ func CloneDocument(value interface{}) interface{} {
 }
 
 // GetKeys returns all keys in the given object
-func GetKeys(m map[string]interface{}) []string {
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		keys = append(keys, key)
-	}
-
-	return keys
-}
-
-// GetKeysString returns all keys in the given map[string]string
-func GetKeysString(m map[string]string) []string {
+func GetKeys[T any](m map[string]T) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)


### PR DESCRIPTION
## Summary

This may seem like a mundane merge request, but it delivers significant performance improvements. Benchmarks show that this library now outperforms jsonld.js.

**Note**: While the changes may appear straightforward, caution is required when implementing them. It is sometimes necessary to differentiate between a value explicitly set to `null` in the context and one that is simply absent.

PS: I don't have any other changes lined up (I couldn't submit this PR earlier because it builds upon #82 to avoid merge conflicts).

**Details**:

- Replace maps with structs to achieve significant performance gains.
- Improve type-safety. Previously, type confusion resulted in unnecessary checks, such as comparing a known string value against a boolean.
- Ensure defaultLanguage always contains a language. Previously, a missing if-check could result in defaultLanguage being set to "_%s", with %s being the direction.
- Remove GetKeysString since it's not used anywhere and is equivalent to the generic GetKeys now.

## Basic example

No change in behavior.

## Motivation

Performance! Additionally, the struct-based design enhances code navigation/reasoning (especially when using an LSP).

## Checks

- [X] Passes `make test`
