### PR TITLE
perf: optimize map iteration and string handling in n-quad parsing

### DIFF
--- a/ld/utils.go
+++ b/ld/utils.go
@@ -53,8 +53,8 @@ func DeepCompare(v1 interface{}, v2 interface{}, listOrderMatters bool) bool {
 		if len(m1) != len(m2) {
 			return false
 		}
-		for _, key := range GetKeys(m1) {
-			if val2, present := m2[key]; !present || !DeepCompare(m1[key], val2, listOrderMatters) {
+		for key, val1 := range m1 {
+			if val2, present := m2[key]; !present || !DeepCompare(val1, val2, listOrderMatters) {
 				return false
 			}
 		}
@@ -112,6 +112,8 @@ func normalizeValue(v interface{}) string {
 	}
 	if isFloat {
 		return fmt.Sprintf("%f", floatVal)
+	} else if str, isString := v.(string); isString {
+		return str
 	} else {
 		return fmt.Sprintf("%s", v)
 	}


### PR DESCRIPTION
## Summary

- Use direct map iteration in DeepCompare
- Add explicit string handling in normalizeValue to avoid unnecessary and slow formatting

## Basic example

This doesn't change existing behavior.

## Motivation

Performance :)
For example, parsing ~60k n-quads on an AMD Ryzen 7 PRO 8840U now takes 1.7s, down from 5.3s (a ~68% reduction).

## Checks

- [X] Passes `make test`
